### PR TITLE
excluded nan-values from comparing rdms

### DIFF
--- a/pyrsa/inference/crossvalsets.py
+++ b/pyrsa/inference/crossvalsets.py
@@ -96,6 +96,8 @@ def sets_k_fold(rdms, k_rdm=5, k_pattern=5, random=True,
     similar sized groups. This version splits both over rdms and over patterns
     resulting in k_rdm * k_pattern (training, test) pairs.
 
+    If a k is set to 1 the corresponding dimension is not crossvalidated.
+
     Args:
         rdms(pyrsa.rdm.RDMs): rdms to use
         pattern_descriptor(String): descriptor to select pattern groups
@@ -131,8 +133,11 @@ def sets_k_fold(rdms, k_rdm=5, k_pattern=5, random=True,
                              (i_group + 1) * group_size_rdm)
         if i_group < additional_rdms:
             test_idx = np.concatenate((test_idx, [-(i_group+1)]))
-        train_idx = np.setdiff1d(np.arange(len(rdm_select)),
-                                 test_idx)
+        if k_rdm <= 1:
+            train_idx = test_idx
+        else:
+            train_idx = np.setdiff1d(np.arange(len(rdm_select)),
+                                     test_idx)
         rdm_sample_test = [rdm_select[int(idx)] for idx in test_idx]
         rdm_sample_train = [rdm_select[int(idx)] for idx in train_idx]
         rdms_test = rdms.subsample(rdm_descriptor,
@@ -206,7 +211,9 @@ def sets_k_fold_rdm(rdms, k_rdm=5, random=True, rdm_descriptor=None):
 def sets_k_fold_pattern(rdms, pattern_descriptor=None, k=5, random=False):
     """ generates training and test set combinations by splitting into k
     similar sized groups. This version splits in the given order or 
-    randomizes the order
+    randomizes the order. For k=1 training and test_set are whole dataset,
+    i.e. no crossvalidation is performed.
+
     For only crossvalidating over patterns there is no independent training
     set for calculating a noise ceiling for the patterns.
     To express this we set ceil_set to None, which makes the crossvalidation
@@ -240,8 +247,11 @@ def sets_k_fold_pattern(rdms, pattern_descriptor=None, k=5, random=False):
                              (i_group + 1) * group_size)
         if i_group < additional_patterns:
             test_idx = np.concatenate((test_idx, [-(i_group+1)]))
-        train_idx = np.setdiff1d(np.arange(len(pattern_select)),
-                                 test_idx)
+        if k <= 1:
+            train_idx = test_idx
+        else:
+            train_idx = np.setdiff1d(np.arange(len(pattern_select)),
+                                     test_idx)
         pattern_sample_test = [pattern_select[int(idx)] for idx in test_idx]
         pattern_sample_train = [pattern_select[int(idx)] for idx in train_idx]
         rdms_test = rdms.subset_pattern(pattern_descriptor,

--- a/pyrsa/inference/evaluate.py
+++ b/pyrsa/inference/evaluate.py
@@ -328,7 +328,7 @@ def bootstrap_crossval(model, data, method='cosine', fitter=None,
             rdm_descriptor=rdm_descriptor,
             pattern_descriptor=pattern_descriptor)
         if len(np.unique(rdm_sample)) >= k_rdm \
-           and len(np.unique(pattern_sample)) >= k_pattern:
+           and len(np.unique(pattern_sample)) >= 3 * k_pattern:
             train_set, test_set, ceil_set = sets_k_fold(sample,
                 pattern_descriptor=pattern_descriptor,
                 rdm_descriptor=rdm_descriptor,

--- a/pyrsa/inference/evaluate.py
+++ b/pyrsa/inference/evaluate.py
@@ -298,6 +298,10 @@ def bootstrap_crossval(model, data, method='cosine', fitter=None,
                        random=True):
     """evaluates a model by k-fold crossvalidation within a bootstrap
 
+    If a k is set to 1 no crossvalidation is performed over the
+    corresponding dimension.
+
+
     Args:
         model(pyrsa.model.Model): Model to be evaluated
         data(pyrsa.rdm.RDMs): RDM data to use

--- a/pyrsa/rdm/compare.py
+++ b/pyrsa/rdm/compare.py
@@ -283,4 +283,8 @@ def _parse_input_rdms(rdm1, rdm2):
             vector2 = rdm2
     if not vector1.shape[1] == vector2.shape[1]:
         raise ValueError('rdm1 and rdm2 must be RDMs of equal shape')
-    return vector1, vector2
+    vector1_no_nan = vector1[~np.isnan(vector1)].reshape(vector1.shape[0], -1)
+    vector2_no_nan = vector2[~np.isnan(vector2)].reshape(vector2.shape[0], -1)
+    if not vector1_no_nan.shape[1] == vector2_no_nan.shape[1]:
+        raise ValueError('rdm1 and rdm2 have different nan positions')
+    return vector1_no_nan, vector2_no_nan

--- a/pyrsa/rdm/rdms.py
+++ b/pyrsa/rdm/rdms.py
@@ -161,6 +161,10 @@ class RDMs:
     def subsample_pattern(self, by, value):
         """ Returns a subsampled RDMs with repetitions if values are repeated
 
+        This function now generates Nans where the off-diagonal 0s would 
+        appear. These values are trivial to predict for models and thus
+        need to be marked and excluded from the evaluation.
+
         Args:
             by(String): the descriptor by which the subset selection
                         is made from descriptors
@@ -183,7 +187,10 @@ class RDMs:
             selection = np.concatenate(selection)
         else:
             selection = np.where(self.rdm_descriptors[by] == value)
-        dissimilarities = self.get_matrices()[:, selection][:, :, selection]
+        dissimilarities = self.get_matrices()
+        for i_rdm in range(self.n_rdm):
+            np.fill_diagonal(dissimilarities[i_rdm], np.nan)
+        dissimilarities = dissimilarities[:, selection][:, :, selection]
         descriptors = self.descriptors
         pattern_descriptors = extract_dict(
             self.pattern_descriptors, selection)

--- a/pyrsa/util/inference_util.py
+++ b/pyrsa/util/inference_util.py
@@ -68,7 +68,15 @@ def pool_rdm(rdms, method='cosine'):
         rdm_vec = rdm_vec - np.nanmean(rdm_vec, axis=1, keepdims=True)
         rdm_vec = rdm_vec / np.nanstd(rdm_vec, axis=1, keepdims=True)
         rdm_vec = np.nanmean(rdm_vec, axis=0, keepdims=True)
-        rdm_vec = rdm_vec - np.min(rdm_vec)
+        rdm_vec = rdm_vec - np.nanmin(rdm_vec)
+    elif method == 'corr_cov':
+        rdm_vec = rdm_vec - np.mean(rdm_vec, axis=1, keepdims=True)
+        rdm_vec = rdm_vec / np.std(rdm_vec, axis=1, keepdims=True)
+        rdm_vec = np.mean(rdm_vec, axis=0, keepdims=True)
+        rdm_vec = rdm_vec - np.nanmin(rdm_vec)
+    elif method == 'cosine_cov':
+        rdm_vec = rdm_vec/np.mean(rdm_vec, axis=1, keepdims=True)
+        rdm_vec = np.mean(rdm_vec, axis=0, keepdims=True)
     elif method == 'spearman':
         rdm_vec = np.array([_nan_rank_data(v) for v in rdm_vec])
         rdm_vec = np.nanmean(rdm_vec, axis=0, keepdims=True)

--- a/pyrsa/util/inference_util.py
+++ b/pyrsa/util/inference_util.py
@@ -62,21 +62,23 @@ def pool_rdm(rdms, method='cosine'):
     if method == 'euclid':
         rdm_vec = _nan_mean(rdm_vec)
     elif method == 'cosine':
-        rdm_vec = rdm_vec / np.nanmean(rdm_vec, axis=1, keepdims=True)
+        rdm_vec = rdm_vec / np.sqrt(np.nanmean(rdm_vec **2, axis=1,
+                                               keepdims=True))
         rdm_vec = _nan_mean(rdm_vec)
     elif method == 'corr':
         rdm_vec = rdm_vec - np.nanmean(rdm_vec, axis=1, keepdims=True)
         rdm_vec = rdm_vec / np.nanstd(rdm_vec, axis=1, keepdims=True)
         rdm_vec = _nan_mean(rdm_vec)
         rdm_vec = rdm_vec - np.nanmin(rdm_vec)
+    elif method == 'cosine_cov':
+        rdm_vec = rdm_vec / np.sqrt(np.nanmean(rdm_vec **2, axis=1,
+                                               keepdims=True))
+        rdm_vec = _nan_mean(rdm_vec)
     elif method == 'corr_cov':
-        rdm_vec = rdm_vec - np.mean(rdm_vec, axis=1, keepdims=True)
-        rdm_vec = rdm_vec / np.std(rdm_vec, axis=1, keepdims=True)
+        rdm_vec = rdm_vec - np.nanmean(rdm_vec, axis=1, keepdims=True)
+        rdm_vec = rdm_vec / np.nanstd(rdm_vec, axis=1, keepdims=True)
         rdm_vec = _nan_mean(rdm_vec)
         rdm_vec = rdm_vec - np.nanmin(rdm_vec)
-    elif method == 'cosine_cov':
-        rdm_vec = rdm_vec/np.mean(rdm_vec, axis=1, keepdims=True)
-        rdm_vec = _nan_mean(rdm_vec)
     elif method == 'spearman':
         rdm_vec = np.array([_nan_rank_data(v) for v in rdm_vec])
         rdm_vec = _nan_mean(rdm_vec)

--- a/pyrsa/util/inference_util.py
+++ b/pyrsa/util/inference_util.py
@@ -60,34 +60,34 @@ def pool_rdm(rdms, method='cosine'):
     """
     rdm_vec = rdms.get_vectors()
     if method == 'euclid':
-        rdm_vec = np.nanmean(rdm_vec, axis=0, keepdims=True)
+        rdm_vec = _nan_mean(rdm_vec)
     elif method == 'cosine':
         rdm_vec = rdm_vec / np.nanmean(rdm_vec, axis=1, keepdims=True)
-        rdm_vec = np.nanmean(rdm_vec, axis=0, keepdims=True)
+        rdm_vec = _nan_mean(rdm_vec)
     elif method == 'corr':
         rdm_vec = rdm_vec - np.nanmean(rdm_vec, axis=1, keepdims=True)
         rdm_vec = rdm_vec / np.nanstd(rdm_vec, axis=1, keepdims=True)
-        rdm_vec = np.nanmean(rdm_vec, axis=0, keepdims=True)
+        rdm_vec = _nan_mean(rdm_vec)
         rdm_vec = rdm_vec - np.nanmin(rdm_vec)
     elif method == 'corr_cov':
         rdm_vec = rdm_vec - np.mean(rdm_vec, axis=1, keepdims=True)
         rdm_vec = rdm_vec / np.std(rdm_vec, axis=1, keepdims=True)
-        rdm_vec = np.mean(rdm_vec, axis=0, keepdims=True)
+        rdm_vec = _nan_mean(rdm_vec)
         rdm_vec = rdm_vec - np.nanmin(rdm_vec)
     elif method == 'cosine_cov':
         rdm_vec = rdm_vec/np.mean(rdm_vec, axis=1, keepdims=True)
-        rdm_vec = np.mean(rdm_vec, axis=0, keepdims=True)
+        rdm_vec = _nan_mean(rdm_vec)
     elif method == 'spearman':
         rdm_vec = np.array([_nan_rank_data(v) for v in rdm_vec])
-        rdm_vec = np.nanmean(rdm_vec, axis=0, keepdims=True)
+        rdm_vec = _nan_mean(rdm_vec)
     elif method == 'kendall' or method == 'tau-b':
         Warning('Noise ceiling for tau based on averaged ranks!')
         rdm_vec = np.array([_nan_rank_data(v) for v in rdm_vec])
-        rdm_vec = np.nanmean(rdm_vec, axis=0, keepdims=True)
+        rdm_vec = _nan_mean(rdm_vec)
     elif method == 'tau-a':
         Warning('Noise ceiling for tau based on averaged ranks!')
         rdm_vec = np.array([_nan_rank_data(v) for v in rdm_vec])
-        rdm_vec = np.nanmean(rdm_vec, axis=0, keepdims=True)
+        rdm_vec = _nan_mean(rdm_vec)
     else:
         raise ValueError('Unknown RDM comparison method requested!')
     return RDMs(rdm_vec,
@@ -96,6 +96,23 @@ def pool_rdm(rdms, method='cosine'):
                 rdm_descriptors=None,
                 pattern_descriptors=rdms.pattern_descriptors)
 
+
+def _nan_mean(rdm_vector):
+    """ takes the average over a rdm_vector with nans for masked entries
+    without a warning
+    
+    Args:
+        rdm_vector(numpy.ndarray): set of rdm_vectors to be averaged
+    
+    Returns:
+        rdm_mean(numpy.ndarray): the mean rdm
+
+    """
+    nan_idx = ~np.isnan(rdm_vector[0])
+    mean_values = np.mean(rdm_vector[:, nan_idx], axis=0)
+    rdm_mean = np.empty((1,rdm_vector.shape[1])) * np.nan
+    rdm_mean[:, nan_idx] = mean_values
+    return rdm_mean
 
 def _nan_rank_data(rdm_vector):
     """ rank_data for vectors with nan entries

--- a/pyrsa/util/inference_util.py
+++ b/pyrsa/util/inference_util.py
@@ -7,7 +7,7 @@ Created on Thu Feb 13 14:56:15 2020
 """
 
 import numpy as np
-from scipy.stats import rankdata
+from scipy.stats.mstats import rankdata
 from pyrsa.model import Model
 from pyrsa.rdm import RDMs
 from collections.abc import Iterable
@@ -60,26 +60,26 @@ def pool_rdm(rdms, method='cosine'):
     """
     rdm_vec = rdms.get_vectors()
     if method == 'euclid':
-        rdm_vec = np.mean(rdm_vec, axis=0, keepdims=True)
+        rdm_vec = np.nanmean(rdm_vec, axis=0, keepdims=True)
     elif method == 'cosine':
-        rdm_vec = rdm_vec/np.mean(rdm_vec, axis=1, keepdims=True)
-        rdm_vec = np.mean(rdm_vec, axis=0, keepdims=True)
+        rdm_vec = rdm_vec / np.nanmean(rdm_vec, axis=1, keepdims=True)
+        rdm_vec = np.nanmean(rdm_vec, axis=0, keepdims=True)
     elif method == 'corr':
-        rdm_vec = rdm_vec - np.mean(rdm_vec, axis=1, keepdims=True)
-        rdm_vec = rdm_vec / np.std(rdm_vec, axis=1, keepdims=True)
-        rdm_vec = np.mean(rdm_vec, axis=0, keepdims=True)
+        rdm_vec = rdm_vec - np.nanmean(rdm_vec, axis=1, keepdims=True)
+        rdm_vec = rdm_vec / np.nanstd(rdm_vec, axis=1, keepdims=True)
+        rdm_vec = np.nanmean(rdm_vec, axis=0, keepdims=True)
         rdm_vec = rdm_vec - np.min(rdm_vec)
     elif method == 'spearman':
-        rdm_vec = np.array([rankdata(v) for v in rdm_vec])
-        rdm_vec = np.mean(rdm_vec, axis=0, keepdims=True)
+        rdm_vec = np.array([_nan_rank_data(v) for v in rdm_vec])
+        rdm_vec = np.nanmean(rdm_vec, axis=0, keepdims=True)
     elif method == 'kendall' or method == 'tau-b':
         Warning('Noise ceiling for tau based on averaged ranks!')
-        rdm_vec = np.array([rankdata(v) for v in rdm_vec])
-        rdm_vec = np.mean(rdm_vec, axis=0, keepdims=True)
+        rdm_vec = np.array([_nan_rank_data(v) for v in rdm_vec])
+        rdm_vec = np.nanmean(rdm_vec, axis=0, keepdims=True)
     elif method == 'tau-a':
         Warning('Noise ceiling for tau based on averaged ranks!')
-        rdm_vec = np.array([rankdata(v) for v in rdm_vec])
-        rdm_vec = np.mean(rdm_vec, axis=0, keepdims=True)
+        rdm_vec = np.array([_nan_rank_data(v) for v in rdm_vec])
+        rdm_vec = np.nanmean(rdm_vec, axis=0, keepdims=True)
     else:
         raise ValueError('Unknown RDM comparison method requested!')
     return RDMs(rdm_vec,
@@ -87,6 +87,22 @@ def pool_rdm(rdms, method='cosine'):
                 descriptors=rdms.descriptors,
                 rdm_descriptors=None,
                 pattern_descriptors=rdms.pattern_descriptors)
+
+
+def _nan_rank_data(rdm_vector):
+    """ rank_data for vectors with nan entries
+    
+    Args:
+        rdm_vector(numpy.ndarray): the vector to be rank_transformed
+    
+    Returns:
+        ranks(numpy.ndarray): the ranks with nans where the original vector
+            had nans
+
+    """
+    ranks = rankdata(np.ma.masked_invalid(rdm_vector))
+    ranks[ranks==0] = np.nan
+    return ranks
 
 
 def pair_tests(evaluations):

--- a/pyrsa/util/inference_util.py
+++ b/pyrsa/util/inference_util.py
@@ -7,7 +7,7 @@ Created on Thu Feb 13 14:56:15 2020
 """
 
 import numpy as np
-from scipy.stats.mstats import rankdata
+from scipy.stats import rankdata
 from pyrsa.model import Model
 from pyrsa.rdm import RDMs
 from collections.abc import Iterable
@@ -100,8 +100,9 @@ def _nan_rank_data(rdm_vector):
             had nans
 
     """
-    ranks = rankdata(np.ma.masked_invalid(rdm_vector))
-    ranks[ranks==0] = np.nan
+    ranks_no_nan = rankdata(rdm_vector[~np.isnan(rdm_vector)])
+    ranks = np.ones_like(rdm_vector) * np.nan
+    ranks[~np.isnan(rdm_vector)] = ranks_no_nan
     return ranks
 
 

--- a/tests/test_crossval.py
+++ b/tests/test_crossval.py
@@ -54,10 +54,32 @@ class test_crossval(unittest.TestCase):
                     dissimilarity_measure=mes,
                     descriptors=des)
         m = ModelFixed('test', rdms[0])
-        bootstrap_crossval(m, rdms, N=10, k_rdm=2, k_pattern=2,
+        res = bootstrap_crossval(m, rdms, N=10, k_rdm=2, k_pattern=2,
+                                 pattern_descriptor='type',
+                                 rdm_descriptor='session')
+
+    def test_bootstrap_crossval_k1(self):
+        from pyrsa.inference import bootstrap_crossval
+        from pyrsa.rdm import RDMs
+        from pyrsa.model import ModelFixed
+        dis = np.random.rand(11,45)  # 11 10x10 rdms
+        mes = "Euclidean"
+        des = {'subj':0}
+        rdm_des = {'session':np.array([0,1,2,2,4,5,6,7,7,7,7])}
+        pattern_des = {'type':np.array([0,1,2,2,4,5,5,5,6,7])}
+        rdms = RDMs(dissimilarities=dis,
+                    rdm_descriptors=rdm_des,
+                    pattern_descriptors=pattern_des,
+                    dissimilarity_measure=mes,
+                    descriptors=des)
+        m = ModelFixed('test', rdms[0])
+        bootstrap_crossval(m, rdms, N=10, k_rdm=1, k_pattern=2,
                            pattern_descriptor='type',
                            rdm_descriptor='session')
-        
+        bootstrap_crossval(m, rdms, N=10, k_rdm=2, k_pattern=1,
+                           pattern_descriptor='type',
+                           rdm_descriptor='session')
+
     def test_bootstrap_crossval_list(self):
         from pyrsa.inference import bootstrap_crossval
         from pyrsa.rdm import RDMs


### PR DESCRIPTION
implements the change from #60 
For subsampling over pattens now NaNs are produced for off-diagonal comparisons of the same patterns. The compare functions are now told to ignore these nan values. 