### PR TITLE
convert descriptors to numpy array to allow saving

### DIFF
--- a/pyrsa/util/descriptor_utils.py
+++ b/pyrsa/util/descriptor_utils.py
@@ -83,7 +83,9 @@ def check_descriptor_length(descriptor, n):
 
     """
     for k, v in descriptor.items():
-        if np.array(v).shape[0] != n:
+        v = np.array(v)
+        descriptor[k] = v
+        if v.shape[0] != n:
             return False
     return True
 

--- a/pyrsa/util/file_io.py
+++ b/pyrsa/util/file_io.py
@@ -9,6 +9,7 @@ Created on Wed Mar 25 17:59:29 2020
 import h5py
 import pickle
 import numpy as np
+import os
 
 
 def write_dict_hdf5(file, dictionary):
@@ -20,6 +21,9 @@ def write_dict_hdf5(file, dictionary):
         dictionary(dict): the dict to be saved
 
     """
+    if isinstance(file, str):
+        if os.path.exists(file):
+            raise ValueError('File already exists!')
     file = h5py.File(file, 'a')
     file.attrs['pyrsa_version'] = '3.0'
     _write_to_group(file, dictionary)

--- a/pyrsa/util/file_io.py
+++ b/pyrsa/util/file_io.py
@@ -34,7 +34,9 @@ def _write_to_group(group, dictionary):
     for key in dictionary.keys():
         value = dictionary[key]
         if isinstance(value, str):
-            group.attrs[key] = value
+            # needs another conversion to string to catch weird subtypes
+            # like numpy.str_
+            group.attrs[key] = str(value)
         elif isinstance(value, np.ndarray):
             if str(value.dtype)[:2] == '<U':
                 group[key] = value.astype('S')

--- a/pyrsa/util/file_io.py
+++ b/pyrsa/util/file_io.py
@@ -32,7 +32,7 @@ def _write_to_group(group, dictionary):
         if isinstance(value, str):
             group.attrs[key] = value
         elif isinstance(value, np.ndarray):
-            if value.dtype == '<U2':
+            if value.dtype in ['<U2', '<U5']:
                 group[key] = value.astype('S')
             else:
                 group[key] = value

--- a/pyrsa/util/file_io.py
+++ b/pyrsa/util/file_io.py
@@ -12,19 +12,19 @@ import numpy as np
 
 
 def write_dict_hdf5(file, dictionary):
-    """ writes a nested dictionary containing strings & arrays as data into 
+    """ writes a nested dictionary containing strings & arrays as data into
     a hdf5 file
 
     Args:
         file: a filename or opened writable file
-        dictionary(dict): the dict to be saved 
+        dictionary(dict): the dict to be saved
 
     """
     file = h5py.File(file, 'a')
     file.attrs['pyrsa_version'] = '3.0'
     _write_to_group(file, dictionary)
-    
-    
+
+
 def _write_to_group(group, dictionary):
     """ writes a dictionary to a hdf5 group, which can recurse"""
     for key in dictionary.keys():
@@ -32,7 +32,7 @@ def _write_to_group(group, dictionary):
         if isinstance(value, str):
             group.attrs[key] = value
         elif isinstance(value, np.ndarray):
-            if value.dtype in ['<U2', '<U5']:
+            if str(value.dtype)[:2] == '<U':
                 group[key] = value.astype('S')
             else:
                 group[key] = value
@@ -46,7 +46,7 @@ def _write_to_group(group, dictionary):
 
 
 def read_dict_hdf5(file):
-    """ writes a nested dictionary containing strings & arrays as data into 
+    """ writes a nested dictionary containing strings & arrays as data into
     a hdf5 file
 
     Args:
@@ -72,7 +72,7 @@ def _read_group(group):
             dictionary[key] = np.array(group[key])
             if dictionary[key].dtype.type is np.string_:
                 dictionary[key] = np.array(group[key]).astype('unicode')
-            # if (len(dictionary[key].shape) == 1 
+            # if (len(dictionary[key].shape) == 1
             #     and dictionary[key].shape[0] == 1):
             #     dictionary[key] = dictionary[key][0]
     for key in group.attrs.keys():
@@ -81,12 +81,12 @@ def _read_group(group):
 
 
 def write_dict_pkl(file, dictionary):
-    """ writes a nested dictionary containing strings & arrays as data into 
+    """ writes a nested dictionary containing strings & arrays as data into
     a pickle file
 
     Args:
         file: a filename or opened writable file
-        dictionary(dict): the dict to be saved 
+        dictionary(dict): the dict to be saved
 
     """
     if isinstance(file, str):
@@ -96,7 +96,7 @@ def write_dict_pkl(file, dictionary):
 
 
 def read_dict_pkl(file):
-    """ writes a nested dictionary containing strings & arrays as data into 
+    """ writes a nested dictionary containing strings & arrays as data into
     a pickle file
 
     Args:

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -275,11 +275,14 @@ class TestSaveLoad(unittest.TestCase):
         assert np.all(res_loaded.models[0].rdm == m1.rdm)
 
     def test_save_load_result(self):
+        from pyrsa.rdm import RDMs
         from pyrsa.inference import Result
         from pyrsa.inference import load_results
         from pyrsa.model import ModelFixed
         import io
-        m1 = ModelFixed('test1', np.random.rand(10))
+        rdm = RDMs(np.random.rand(10),
+            pattern_descriptors={'test':['test1','test1','test1','test3','test']})
+        m1 = ModelFixed('test1', rdm)
         m2 = ModelFixed('test2', np.random.rand(10))
         models = [m1, m2]
         evaluations = np.random.rand(100,2)


### PR DESCRIPTION
This fixes the error Niko observed in issue #68. For this I now convert descriptors to numpy arrays whenever an object is created. This should remove this problem.


Closes #68 