### PR TITLE
random instead of zeros to remove warnings

### DIFF
--- a/tests/test_vis.py
+++ b/tests/test_vis.py
@@ -14,7 +14,7 @@ import pyrsa.rdm as rsr
 class TestVIS(unittest.TestCase):
 
     def test_vis_mds_output_shape_corresponds_to_inputs(self):
-        dis = np.zeros((8, 10))
+        dis = np.random.rand(8, 10)
         mes = "Euclidean"
         des = {'session': 0, 'subj': 0}
         rdms = rsr.RDMs(dissimilarities=dis,


### PR DESCRIPTION
the vis module test raised many (19000) warnings when running pytest 
This replaces the 0 input with random numbers and gets rid of these warnings. 

Will not do anything else on this branch