### PR TITLE
Bugfix noise ceiling

### DIFF
--- a/pyrsa/inference/bootstrap.py
+++ b/pyrsa/inference/bootstrap.py
@@ -6,7 +6,8 @@
 import numpy as np
 from pyrsa.util.rdm_utils import add_pattern_index
 
-def bootstrap_sample(rdms, rdm_descriptor=None, pattern_descriptor=None):
+
+def bootstrap_sample(rdms, rdm_descriptor='index', pattern_descriptor='index'):
     """Draws a bootstrap_sample from the data.
 
     This function generates a bootstrap sample of RDMs resampled over
@@ -38,12 +39,7 @@ def bootstrap_sample(rdms, rdm_descriptor=None, pattern_descriptor=None):
             sampled pattern descriptor indices
 
     """
-    if rdm_descriptor is None:
-        rdm_select = np.arange(rdms.n_rdm)
-        rdms.rdm_descriptors['index'] = rdm_select
-        rdm_descriptor = 'index'
-    else:
-        rdm_select = np.unique(rdms.rdm_descriptors[rdm_descriptor])
+    rdm_select = np.unique(rdms.rdm_descriptors[rdm_descriptor])
     pattern_descriptor, pattern_select = \
         add_pattern_index(rdms, pattern_descriptor)
     rdm_sample = np.random.randint(0, len(rdm_select) - 1,
@@ -58,7 +54,7 @@ def bootstrap_sample(rdms, rdm_descriptor=None, pattern_descriptor=None):
     return rdms, rdm_sample, pattern_sample
 
 
-def bootstrap_sample_rdm(rdms, rdm_descriptor=None):
+def bootstrap_sample_rdm(rdms, rdm_descriptor='index'):
     """Draws a bootstrap_sample from the data.
 
     This function generates a bootstrap sample of RDMs resampled over
@@ -84,12 +80,7 @@ def bootstrap_sample_rdm(rdms, rdm_descriptor=None):
             rdm group descritor values
 
     """
-    if rdm_descriptor is None:
-        rdm_select = np.arange(rdms.n_rdm)
-        rdms.rdm_descriptors['index'] = rdm_select
-        rdm_descriptor = 'index'
-    else:
-        rdm_select = np.unique(rdms.rdm_descriptors[rdm_descriptor])
+    rdm_select = np.unique(rdms.rdm_descriptors[rdm_descriptor])
     rdm_sample = np.random.randint(0, len(rdm_select) - 1,
                                    size=len(rdm_select))
     rdm_sample = rdm_select[rdm_sample]
@@ -97,7 +88,7 @@ def bootstrap_sample_rdm(rdms, rdm_descriptor=None):
     return rdms, rdm_sample
 
 
-def bootstrap_sample_pattern(rdms, pattern_descriptor=None):
+def bootstrap_sample_pattern(rdms, pattern_descriptor='index'):
     """Draws a bootstrap_sample from the data.
 
     This function generates a bootstrap sample of RDMs resampled over

--- a/pyrsa/inference/crossvalsets.py
+++ b/pyrsa/inference/crossvalsets.py
@@ -48,7 +48,7 @@ def sets_leave_one_out_pattern(rdms, pattern_descriptor):
     return train_set, test_set, ceil_set
 
 
-def sets_leave_one_out_rdm(rdms, rdm_descriptor=None):
+def sets_leave_one_out_rdm(rdms, rdm_descriptor='index'):
     """ generates training and test set combinations by leaving one level
     of rdm_descriptor out as a test set.\
 
@@ -62,14 +62,9 @@ def sets_leave_one_out_rdm(rdms, rdm_descriptor=None):
         ceil_set(list): list of tuples (rdms, pattern_sample)
 
     """
-    if rdm_descriptor is None:
-        rdm_select = np.arange(rdms.n_rdm)
-        rdms.rdm_descriptors['index'] = rdm_select
-        rdm_descriptor = 'index'
-    else:
-        rdm_select = rdms.rdm_descriptors[rdm_descriptor]
-        rdm_select = np.unique(rdm_select)
-    if len(rdm_select) > 1: 
+    rdm_select = rdms.rdm_descriptors[rdm_descriptor]
+    rdm_select = np.unique(rdm_select)
+    if len(rdm_select) > 1:
         train_set = []
         test_set = []
         for i_pattern in rdm_select:
@@ -91,7 +86,7 @@ def sets_leave_one_out_rdm(rdms, rdm_descriptor=None):
 
 
 def sets_k_fold(rdms, k_rdm=5, k_pattern=5, random=True,
-                pattern_descriptor=None, rdm_descriptor=None):
+                pattern_descriptor=None, rdm_descriptor='index'):
     """ generates training and test set combinations by splitting into k
     similar sized groups. This version splits both over rdms and over patterns
     resulting in k_rdm * k_pattern (training, test) pairs.
@@ -112,13 +107,8 @@ def sets_k_fold(rdms, k_rdm=5, k_pattern=5, random=True,
         ceil_set(list): list of tuples (rdms, pattern_sample)
 
     """
-    if rdm_descriptor is None:
-        rdm_select = np.arange(rdms.n_rdm)
-        rdms.rdm_descriptors['index'] = rdm_select
-        pattern_descriptor = 'index'
-    else:
-        rdm_select = rdms.rdm_descriptors[rdm_descriptor]
-        rdm_select = np.unique(rdm_select)
+    rdm_select = rdms.rdm_descriptors[rdm_descriptor]
+    rdm_select = np.unique(rdm_select)
     assert k_rdm <= len(rdm_select), \
         'Can make at most as many groups as rdms'
     if random:
@@ -144,7 +134,8 @@ def sets_k_fold(rdms, k_rdm=5, k_pattern=5, random=True,
                                    rdm_sample_test)
         rdms_train = rdms.subsample(rdm_descriptor,
                                     rdm_sample_train)
-        train_new, test_new, _ = sets_k_fold_pattern(rdms_train, k=k_pattern,
+        train_new, test_new, _ = sets_k_fold_pattern(
+            rdms_train, k=k_pattern,
             pattern_descriptor=pattern_descriptor, random=random)
         ceil_new = test_new.copy()
         for i_pattern in range(k_pattern):
@@ -157,7 +148,7 @@ def sets_k_fold(rdms, k_rdm=5, k_pattern=5, random=True,
     return train_set, test_set, ceil_set
 
 
-def sets_k_fold_rdm(rdms, k_rdm=5, random=True, rdm_descriptor=None):
+def sets_k_fold_rdm(rdms, k_rdm=5, random=True, rdm_descriptor='index'):
     """ generates training and test set combinations by splitting into k
     similar sized groups. This version splits both over rdms and over patterns
     resulting in k_rdm * k_pattern (training, test) pairs.
@@ -173,13 +164,8 @@ def sets_k_fold_rdm(rdms, k_rdm=5, random=True, rdm_descriptor=None):
         test_set(list): list of tuples (rdms, pattern_sample)
 
     """
-    if rdm_descriptor is None:
-        rdm_select = np.arange(rdms.n_rdm)
-        rdms.rdm_descriptors['index'] = rdm_select
-        rdm_descriptor = 'index'
-    else:
-        rdm_select = rdms.rdm_descriptors[rdm_descriptor]
-        rdm_select = np.unique(rdm_select)
+    rdm_select = rdms.rdm_descriptors[rdm_descriptor]
+    rdm_select = np.unique(rdm_select)
     assert k_rdm <= len(rdm_select), \
         'Can make at most as many groups as rdms'
     if random:
@@ -205,12 +191,11 @@ def sets_k_fold_rdm(rdms, k_rdm=5, random=True, rdm_descriptor=None):
         test_set.append([rdms_test, np.arange(rdms_train.n_cond)])
     ceil_set = train_set
     return train_set, test_set, ceil_set
-    
 
 
-def sets_k_fold_pattern(rdms, pattern_descriptor=None, k=5, random=False):
+def sets_k_fold_pattern(rdms, pattern_descriptor='index', k=5, random=False):
     """ generates training and test set combinations by splitting into k
-    similar sized groups. This version splits in the given order or 
+    similar sized groups. This version splits in the given order or
     randomizes the order. For k=1 training and test_set are whole dataset,
     i.e. no crossvalidation is performed.
 
@@ -264,9 +249,9 @@ def sets_k_fold_pattern(rdms, pattern_descriptor=None, k=5, random=False):
     return train_set, test_set, ceil_set
 
 
-def sets_of_k_rdm(rdms, rdm_descriptor=None, k=5, random=False):
+def sets_of_k_rdm(rdms, rdm_descriptor='index', k=5, random=False):
     """ generates training and test set combinations by splitting into
-    groups of k. This version splits in the given order or 
+    groups of k. This version splits in the given order or
     randomizes the order. If the number of patterns is not divisible by k
     patterns are added to the first groups such that those have k+1 patterns
 
@@ -282,23 +267,18 @@ def sets_of_k_rdm(rdms, rdm_descriptor=None, k=5, random=False):
         ceil_set(list): list of tuples (rdms, pattern_sample)
 
     """
-    if rdm_descriptor is None:
-        rdm_select = np.arange(rdms.n_rdm)
-        rdms.rdm_descriptors['index'] = rdm_select
-        rdm_descriptor = 'index'
-    else:
-        rdm_select = rdms.rdm_descriptors[rdm_descriptor]
-        rdm_select = np.unique(rdm_select)
+    rdm_select = rdms.rdm_descriptors[rdm_descriptor]
+    rdm_select = np.unique(rdm_select)
     assert k <= len(rdm_select) / 2, \
         'to form groups we can use at most half the patterns per group'
     n_groups = int(len(rdm_select) / k)
     return sets_k_fold_rdm(rdms, rdm_descriptor=rdm_descriptor,
-                               k=n_groups, random=random)
+                           k=n_groups, random=random)
 
 
 def sets_of_k_pattern(rdms, pattern_descriptor=None, k=5, random=False):
     """ generates training and test set combinations by splitting into
-    groups of k. This version splits in the given order or 
+    groups of k. This version splits in the given order or
     randomizes the order. If the number of patterns is not divisible by k
     patterns are added to the first groups such that those have k+1 patterns
 

--- a/pyrsa/inference/evaluate.py
+++ b/pyrsa/inference/evaluate.py
@@ -42,20 +42,19 @@ def eval_fixed(model, data, theta=None, method='cosine'):
         for k in range(len(model)):
             rdm_pred = model[k].predict_rdm(theta=theta[k])
             evaluations[k] = np.mean(compare(rdm_pred, data, method)[0])
-        evaluations = evaluations.reshape((1,len(model)))
+        evaluations = evaluations.reshape((1, len(model)))
     else:
         raise ValueError('model should be a pyrsa.model.Model or a list of'
                          + ' such objects')
-    noise_ceil = boot_noise_ceiling(data,
-            method=method, rdm_descriptor='index')
+    noise_ceil = boot_noise_ceiling(
+        data, method=method, rdm_descriptor='index')
     result = Result(model, evaluations, method=method,
                     cv_method='fixed', noise_ceiling=noise_ceil)
     return result
-        
 
 
 def eval_bootstrap(model, data, theta=None, method='cosine', N=1000,
-                   pattern_descriptor=None, rdm_descriptor=None,
+                   pattern_descriptor='index', rdm_descriptor='index',
                    boot_noise_ceil=True):
     """evaluates a model on data
     performs bootstrapping to get a sampling distribution
@@ -96,31 +95,31 @@ def eval_bootstrap(model, data, theta=None, method='cosine', N=1000,
                                                         method))
                     j += 1
             if boot_noise_ceil:
-                noise_min_sample, noise_max_sample = boot_noise_ceiling(sample,
-                    method=method, rdm_descriptor=rdm_descriptor)
+                noise_min_sample, noise_max_sample = boot_noise_ceiling(
+                    sample, method=method, rdm_descriptor=rdm_descriptor)
                 noise_min.append(noise_min_sample)
                 noise_max.append(noise_max_sample)
         else:
-            if isinstance(model, Model):   
+            if isinstance(model, Model):
                 evaluations[i] = np.nan
             elif isinstance(model, Iterable):
                 evaluations[i, :] = np.nan
             noise_min.append(np.nan)
             noise_max.append(np.nan)
     if isinstance(model, Model):
-        evaluations = evaluations.reshape((N,1))
+        evaluations = evaluations.reshape((N, 1))
     if boot_noise_ceil:
         noise_ceil = np.array([noise_min, noise_max])
     else:
-        noise_ceil = np.array(boot_noise_ceiling(data,
-            method=method, rdm_descriptor=rdm_descriptor))
+        noise_ceil = np.array(boot_noise_ceiling(
+            data, method=method, rdm_descriptor=rdm_descriptor))
     result = Result(model, evaluations, method=method,
                     cv_method='bootstrap', noise_ceiling=noise_ceil)
     return result
 
 
 def eval_bootstrap_pattern(model, data, theta=None, method='cosine', N=1000,
-                           pattern_descriptor=None, rdm_descriptor=None,
+                           pattern_descriptor='index', rdm_descriptor='index',
                            boot_noise_ceil=True):
     """evaluates a model on data
     performs bootstrapping over patterns to get a sampling distribution
@@ -161,31 +160,31 @@ def eval_bootstrap_pattern(model, data, theta=None, method='cosine', N=1000,
                                                         method))
                     j += 1
             if boot_noise_ceil:
-                noise_min_sample, noise_max_sample = boot_noise_ceiling(sample,
-                    method=method, rdm_descriptor=rdm_descriptor)
+                noise_min_sample, noise_max_sample = boot_noise_ceiling(
+                    sample, method=method, rdm_descriptor=rdm_descriptor)
                 noise_min.append(noise_min_sample)
                 noise_max.append(noise_max_sample)
         else:
-            if isinstance(model, Model):   
+            if isinstance(model, Model):
                 evaluations[i] = np.nan
             elif isinstance(model, Iterable):
                 evaluations[i, :] = np.nan
             noise_min.append(np.nan)
             noise_max.append(np.nan)
     if isinstance(model, Model):
-        evaluations = evaluations.reshape((N,1))
+        evaluations = evaluations.reshape((N, 1))
     if boot_noise_ceil:
         noise_ceil = np.array([noise_min, noise_max])
     else:
-        noise_ceil = np.array(boot_noise_ceiling(data,
-            method=method, rdm_descriptor=rdm_descriptor))
+        noise_ceil = np.array(boot_noise_ceiling(
+            data, method=method, rdm_descriptor=rdm_descriptor))
     result = Result(model, evaluations, method=method,
                     cv_method='bootstrap_pattern', noise_ceiling=noise_ceil)
     return result
 
 
 def eval_bootstrap_rdm(model, data, theta=None, method='cosine', N=1000,
-                       rdm_descriptor=None, boot_noise_ceil=True):
+                       rdm_descriptor='index', boot_noise_ceil=True):
     """evaluates a model on data
     performs bootstrapping to get a sampling distribution
 
@@ -217,24 +216,24 @@ def eval_bootstrap_rdm(model, data, theta=None, method='cosine', N=1000,
                                                     method))
                 j += 1
         if boot_noise_ceil:
-            noise_min_sample, noise_max_sample = boot_noise_ceiling(sample,
-                method=method, rdm_descriptor=rdm_descriptor)
+            noise_min_sample, noise_max_sample = boot_noise_ceiling(
+                sample, method=method, rdm_descriptor=rdm_descriptor)
             noise_min.append(noise_min_sample)
             noise_max.append(noise_max_sample)
     if isinstance(model, Model):
-        evaluations = evaluations.reshape((N,1))
+        evaluations = evaluations.reshape((N, 1))
     if boot_noise_ceil:
         noise_ceil = np.array([noise_min, noise_max])
     else:
-        noise_ceil = np.array(boot_noise_ceiling(data,
-            method=method, rdm_descriptor=rdm_descriptor))
+        noise_ceil = np.array(boot_noise_ceiling(
+            data, method=method, rdm_descriptor=rdm_descriptor))
     result = Result(model, evaluations, method=method,
                     cv_method='bootstrap_rdm', noise_ceiling=noise_ceil)
     return result
 
 
 def crossval(model, rdms, train_set, test_set, ceil_set=None, method='cosine',
-             fitter=None, pattern_descriptor=None):
+             fitter=None, pattern_descriptor='index'):
     """evaluates a model on cross-validation sets
 
     Args:
@@ -256,8 +255,6 @@ def crossval(model, rdms, train_set, test_set, ceil_set=None, method='cosine',
     if ceil_set is not None:
         assert len(ceil_set) == len(test_set), \
             'ceil_set and test_set must have the same length'
-    if pattern_descriptor is None:
-        pattern_descriptor = 'index'
     evaluations = []
     noise_ceil = []
     for i in range(len(train_set)):
@@ -283,21 +280,23 @@ def crossval(model, rdms, train_set, test_set, ceil_set=None, method='cosine',
             elif isinstance(model, Iterable):
                 evals, _, fitter = input_check_model(model, None, fitter)
                 for j in range(len(model)):
-                    theta = fitter[j](model[j], train[0], method=method,
-                                        pattern_sample=train[1],
-                                        pattern_descriptor=pattern_descriptor)
+                    theta = fitter[j](
+                        model[j], train[0], method=method,
+                        pattern_sample=train[1],
+                        pattern_descriptor=pattern_descriptor)
                     pred = model[j].predict_rdm(theta)
                     pred = pred.subsample_pattern(by=pattern_descriptor,
                                                   value=test[1])
                     evals[j] = np.mean(compare(pred, test[0], method))
             if ceil_set is None:
                 noise_ceil.append(boot_noise_ceiling(
-                    rdms.subsample_pattern(by=pattern_descriptor, value=test[1])
-                    , method=method))
+                    rdms.subsample_pattern(
+                        by=pattern_descriptor, value=test[1]),
+                    method=method))
         evaluations.append(evals)
     if isinstance(model, Model):
         model = [model]
-    evaluations = np.array(evaluations).T # .T to switch model/set order
+    evaluations = np.array(evaluations).T  # .T to switch model/set order
     evaluations = evaluations.reshape((1, len(model), len(train_set)))
     if ceil_set is not None:
         noise_ceil = cv_noise_ceiling(rdms, ceil_set, test_set, method=method,
@@ -311,7 +310,7 @@ def crossval(model, rdms, train_set, test_set, ceil_set=None, method='cosine',
 
 def bootstrap_crossval(model, data, method='cosine', fitter=None,
                        k_pattern=5, k_rdm=5, N=1000,
-                       pattern_descriptor=None, rdm_descriptor=None,
+                       pattern_descriptor='index', rdm_descriptor='index',
                        random=True):
     """evaluates a model by k-fold crossvalidation within a bootstrap
 
@@ -341,12 +340,13 @@ def bootstrap_crossval(model, data, method='cosine', fitter=None,
         evaluations = np.zeros((N, len(model), k_pattern * k_rdm))
     noise_ceil = np.zeros((2, N))
     for i_sample in tqdm.trange(N):
-        sample, rdm_sample, pattern_sample = bootstrap_sample(data,
-            rdm_descriptor=rdm_descriptor,
+        sample, rdm_sample, pattern_sample = bootstrap_sample(
+            data, rdm_descriptor=rdm_descriptor,
             pattern_descriptor=pattern_descriptor)
         if len(np.unique(rdm_sample)) >= k_rdm \
            and len(np.unique(pattern_sample)) >= 3 * k_pattern:
-            train_set, test_set, ceil_set = sets_k_fold(sample,
+            train_set, test_set, ceil_set = sets_k_fold(
+                sample,
                 pattern_descriptor=pattern_descriptor,
                 rdm_descriptor=rdm_descriptor,
                 k_pattern=k_pattern, k_rdm=k_rdm, random=random)
@@ -355,30 +355,31 @@ def bootstrap_crossval(model, data, method='cosine', fitter=None,
                                                     test_set[idx][1])
                 train_set[idx][1] = _concat_sampling(pattern_sample,
                                                      train_set[idx][1])
-            cv_result = crossval(model, sample,
+            cv_result = crossval(
+                model, sample,
                 train_set, test_set,
-                method=method, fitter=fitter, 
+                method=method, fitter=fitter,
                 pattern_descriptor=pattern_descriptor)
-            if isinstance(model, Model):   
+            if isinstance(model, Model):
                 evaluations[i_sample, 0, :] = cv_result.evaluations[0, 0]
             elif isinstance(model, Iterable):
                 evaluations[i_sample, :, :] = cv_result.evaluations[0]
-            noise_ceil[:,i_sample] = np.mean(cv_result.noise_ceiling, axis=-1)
-        else: # sample does not allow desired crossvalidation
-            if isinstance(model, Model):   
+            noise_ceil[:, i_sample] = np.mean(cv_result.noise_ceiling, axis=-1)
+        else:  # sample does not allow desired crossvalidation
+            if isinstance(model, Model):
                 evaluations[i_sample, 0, :] = np.nan
             elif isinstance(model, Iterable):
                 evaluations[i_sample, :, :] = np.nan
-            noise_ceil[:,i_sample] = np.nan
+            noise_ceil[:, i_sample] = np.nan
     result = Result(model, evaluations, method=method,
                     cv_method='bootstrap_crossval', noise_ceiling=noise_ceil)
     return result
 
 
 def _concat_sampling(sample1, sample2):
-    """ computes an index vector for the sequential sampling with sample1 
+    """ computes an index vector for the sequential sampling with sample1
     and sample2
     """
-    sample_out = [[i_samp1 for i_samp1 in sample1 if i_samp1==i_samp2]
+    sample_out = [[i_samp1 for i_samp1 in sample1 if i_samp1 == i_samp2]
                   for i_samp2 in sample2]
-    return sum(sample_out,[])
+    return sum(sample_out, [])

--- a/pyrsa/inference/noise_ceiling.py
+++ b/pyrsa/inference/noise_ceiling.py
@@ -11,6 +11,7 @@ from pyrsa.util.inference_util import pool_rdm
 from pyrsa.rdm import compare
 from .crossvalsets import sets_leave_one_out_rdm
 
+
 def cv_noise_ceiling(rdms, ceil_set, test_set, method='cosine',
                      pattern_descriptor=None):
     """ calculates the noise ceiling for crossvalidation.
@@ -42,10 +43,10 @@ def cv_noise_ceiling(rdms, ceil_set, test_set, method='cosine',
         train = ceil_set[i]
         test = test_set[i]
         pred_train = pool_rdm(train[0], method=method)
-        pred_train = pred_train.subsample_pattern(by=pattern_descriptor, 
+        pred_train = pred_train.subsample_pattern(by=pattern_descriptor,
                                                   value=test[1])
         pred_test = pool_rdm(rdms, method=method)
-        pred_test = pred_test.subsample_pattern(by=pattern_descriptor, 
+        pred_test = pred_test.subsample_pattern(by=pattern_descriptor,
                                                 value=test[1])
         noise_min.append(np.mean(compare(pred_train, test[0], method)))
         noise_max.append(np.mean(compare(pred_test, test[0], method)))

--- a/pyrsa/inference/noise_ceiling.py
+++ b/pyrsa/inference/noise_ceiling.py
@@ -13,7 +13,7 @@ from .crossvalsets import sets_leave_one_out_rdm
 
 
 def cv_noise_ceiling(rdms, ceil_set, test_set, method='cosine',
-                     pattern_descriptor=None):
+                     pattern_descriptor='index'):
     """ calculates the noise ceiling for crossvalidation.
     The upper bound is calculated by pooling all rdms for the appropriate
     patterns in the testsets.
@@ -35,8 +35,6 @@ def cv_noise_ceiling(rdms, ceil_set, test_set, method='cosine',
     """
     assert len(ceil_set) == len(test_set), \
         'train_set and test_set must have the same length'
-    if pattern_descriptor is None:
-        pattern_descriptor = 'index'
     noise_min = []
     noise_max = []
     for i in range(len(ceil_set)):
@@ -55,7 +53,7 @@ def cv_noise_ceiling(rdms, ceil_set, test_set, method='cosine',
     return noise_min, noise_max
 
 
-def boot_noise_ceiling(rdms, method='cosine', rdm_descriptor=None):
+def boot_noise_ceiling(rdms, method='cosine', rdm_descriptor='index'):
     """ calculates a noise ceiling by leave one out & full set
 
     Args:

--- a/pyrsa/util/rdm_utils.py
+++ b/pyrsa/util/rdm_utils.py
@@ -97,10 +97,6 @@ def add_pattern_index(rdms, pattern_descriptor):
         pattern_select
 
     """
-    if pattern_descriptor is None:
-        pattern_select = np.arange(rdms.n_cond)
-        pattern_descriptor = 'index'
-    else:
-        pattern_select = rdms.pattern_descriptors[pattern_descriptor]
-        pattern_select = np.unique(pattern_select)
+    pattern_select = rdms.pattern_descriptors[pattern_descriptor]
+    pattern_select = np.unique(pattern_select)
     return pattern_descriptor, pattern_select


### PR DESCRIPTION
This fixes a problem observed Baihan for the computation of the noise ceiling. 
The problem was that if no descriptor name was provided such a distinction was created newly for each bootstrap sample such that subjects could appear in both training and test set for the estimation of the lower bound on the noise ceiling, which inflated this bound. 

Please check and merge soon!