### PR TITLE
conversion of notebooks to sphinx: proof of concept

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -109,4 +109,9 @@ venv.bak/
 
 # mypy
 .mypy_cache/
-Icon[]
+Icon[
+]
+
+# nbsphinx_link copies
+docs/source/92imageData/
+docs/source/rdms_inferring/

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -44,6 +44,8 @@ extensions = [
     'sphinx.ext.coverage',
     'sphinx.ext.viewcode',
     'sphinx.ext.napoleon',
+    'nbsphinx',
+    'nbsphinx_link'
 ]
 
 napoleon_google_docstring = True
@@ -184,3 +186,4 @@ epub_exclude_files = ['search.html']
 
 
 # -- Extension configuration -------------------------------------------------
+nbsphinx_allow_errors = True

--- a/docs/source/demos.rst
+++ b/docs/source/demos.rst
@@ -3,5 +3,6 @@ Demos
 
 
 .. toctree::
+   :maxdepth: 2
 
    exercise_all

--- a/docs/source/demos.rst
+++ b/docs/source/demos.rst
@@ -1,0 +1,7 @@
+Demos
+=====
+
+
+.. toctree::
+
+   exercise_all

--- a/docs/source/exercise_all.nblink
+++ b/docs/source/exercise_all.nblink
@@ -1,0 +1,7 @@
+{
+    "path": "../../demos/exercise_all.ipynb",
+    "extra-media": [
+        "../../demos/92imageData",
+        "../../demos/rdms_inferring"
+    ]
+}

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -22,6 +22,7 @@ Documentation
    inference.rst
    visualization.rst
    literature_cited.rst
+   demos
    pyrsa.rst
 
 Indices and tables

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,5 @@ tqdm
 h5py
 matplotlib
 joblib
+nbsphinx
+nbsphinx-link


### PR DESCRIPTION
This is a basic way to include the demo notebooks in the narrative documentation.

resolves #107 

It remains to be seen if this will also work on `readthedocs`, as obviously running all the cells is not exactly lightweight.