### PR TITLE
RDMs implements __len__.

### DIFF
--- a/pyrsa/rdm/rdms.py
+++ b/pyrsa/rdm/rdms.py
@@ -107,6 +107,7 @@ class RDMs:
     def __getitem__(self, idx):
         """
         allows indexing with []
+        and iterating over RDMs with `for rdm in rdms:`
         """
         idx = np.array(idx)
         dissimilarities = self.dissimilarities[idx].reshape(-1,
@@ -118,6 +119,13 @@ class RDMs:
                     rdm_descriptors=rdm_descriptors,
                     pattern_descriptors=self.pattern_descriptors)
         return rdms
+
+    def __len__(self) -> int:
+        """
+        The number of RDMs in this stack.
+        Together with __getitem__, allows `reversed(rdms)`.
+        """
+        return self.n_rdm
 
     def get_vectors(self):
         """ Returns RDMs as np.ndarray with each RDM as a vector

--- a/tests/test_rdm.py
+++ b/tests/test_rdm.py
@@ -161,6 +161,53 @@ class TestRDM(unittest.TestCase):
         self.assertEqual(rdms_sample.n_rdm, 3)
         assert_array_equal(rdms_sample.dissimilarities[0], dis[3])
 
+    def test_rdm_len(self):
+        n_rdm, n_cond = 7, 10
+        dis = np.zeros((n_rdm, n_cond, n_cond))
+        rdms = rsr.RDMs(dissimilarities=dis,
+                        pattern_descriptors={'type': np.array(list(range(n_cond)))},
+                        dissimilarity_measure='Euclidean',
+                        descriptors={'subj': range(n_rdm)})
+        self.assertEqual(len(rdms), n_rdm)
+
+    def test_rdm_idx_len_is_1(self):
+        n_rdm, n_cond = 7, 10
+        dis = np.zeros((n_rdm, n_cond, n_cond))
+        rdms = rsr.RDMs(dissimilarities=dis,
+                        pattern_descriptors={'type': np.array(list(range(n_cond)))},
+                        dissimilarity_measure='Euclidean',
+                        descriptors={'subj': range(n_rdm)})
+        self.assertEqual(len(rdms[0]), 1)
+
+    def test_rdm_subset_len(self):
+        subset_idxs = [0, 1, 2]
+        dis = np.zeros((8, 10))
+        mes = "Euclidean"
+        des = {'subj': 0}
+        rdm_des = {'session': np.array([0, 1, 2, 3, 4, 5, 6, 7])}
+        rdms = rsr.RDMs(dissimilarities=dis,
+                        rdm_descriptors=rdm_des,
+                        dissimilarity_measure=mes,
+                        descriptors=des)
+        rdms_subset = rdms.subset('session', np.array(subset_idxs))
+        self.assertEqual(len(rdms_subset), len(subset_idxs))
+
+    def test_rdm_iter(self):
+        dis = np.zeros((8, 10))
+        mes = "Euclidean"
+        des = {'subj': 0}
+        rdm_des = {'session': np.array([0, 1, 2, 2, 4, 5, 6, 7])}
+        rdms = rsr.RDMs(dissimilarities=dis,
+                        rdm_descriptors=rdm_des,
+                        dissimilarity_measure=mes,
+                        descriptors=des)
+        i = 0
+        for rdm in rdms:
+            self.assertIsInstance(rdm, rsr.RDMs)
+            self.assertEqual(len(rdm), 1)
+            i += 1
+        self.assertEqual(i, rdms.n_rdm)
+
     def test_rank_transform(self):
         from pyrsa.rdm import rank_transform
         dis = np.zeros((8, 10))

--- a/tests/test_rdm.py
+++ b/tests/test_rdm.py
@@ -205,6 +205,7 @@ class TestRDM(unittest.TestCase):
         for rdm in rdms:
             self.assertIsInstance(rdm, rsr.RDMs)
             self.assertEqual(len(rdm), 1)
+            assert_array_equal(rdm.dissimilarities, rdms[i].dissimilarities)
             i += 1
         self.assertEqual(i, rdms.n_rdm)
 


### PR DESCRIPTION
We can already check the number of RDMs in a stack by using `RDMs.n_rdm`.  However, providing this through `__len__` has advantages:
- It is idiomatic: people will try to use `len(rdms)`, and this will give them what they're looking for.
- Together with `__getitem__`, which provides for iteration with `for rdm in rdms:`, `__len__` lets you use `reversed(rdms)`, which can be useful in some contexts.