### PR TITLE
bug fix: avoid descriptor exceptions on 0d arrays (e.g. strings)

### DIFF
--- a/pyrsa/util/descriptor_utils.py
+++ b/pyrsa/util/descriptor_utils.py
@@ -68,13 +68,13 @@ def parse_input_descriptor(descriptors):
     return descriptors
 
 
-def check_descriptor_length(descriptor, n):
+def check_descriptor_length(descriptor, n_element):
     """
     Checks whether the entries of a descriptor dictionary have the right length
 
     Args:
         descriptor(dict): the descriptor dictionary
-        n: the correct length of the descriptors
+        n_element: the correct length of the descriptors
 
     Returns:
         bool
@@ -83,7 +83,7 @@ def check_descriptor_length(descriptor, n):
     for k, v in descriptor.items():
         v = np.array(v)
         descriptor[k] = v
-        if v.shape[0] != n:
+        if v.shape[0] != n_element:
             return False
     return True
 
@@ -130,20 +130,20 @@ def append_descriptor(descriptor, desc_new):
     return descriptor
 
 
-def check_descriptor_length_error(descriptor, name, n):
+def check_descriptor_length_error(descriptor, name, n_element):
     """
     Raises an error if the given descriptor does not have the right length
 
     Args:
         descriptor(dict/None): the descriptor dictionary
         name(String): Descriptor name used for error message
-        n: the desired descriptor length
+        n_element: the desired descriptor length
 
     Returns:
         ---
 
     """
     if descriptor is not None:
-        if not check_descriptor_length(descriptor, n):
+        if not check_descriptor_length(descriptor, n_element):
             raise AttributeError(
                 name + " have mismatched dimension with measurements.")

--- a/pyrsa/util/descriptor_utils.py
+++ b/pyrsa/util/descriptor_utils.py
@@ -81,7 +81,10 @@ def check_descriptor_length(descriptor, n_element):
 
     """
     for k, v in descriptor.items():
-        v = np.array(v)
+        v = np.asarray(v)
+        if not v.shape:
+            # 0-d array happens e.g. when casting str to array
+            v = v.flatten()
         descriptor[k] = v
         if v.shape[0] != n_element:
             return False

--- a/tests/test_descriptor_utils.py
+++ b/tests/test_descriptor_utils.py
@@ -44,6 +44,12 @@ class TestDescriptorUtils(TestCase):
         descriptors = {'foo': ['bar']}
         assert check_descriptor_length(descriptors, 1)
 
+    def test_check_descriptor_length_0d(self):
+        """numpy casts str to 0d arrays (arrays with empty shape). This breaks things."""
+        from pyrsa.util.descriptor_utils import check_descriptor_length
+        descriptors = {'foo': 'bar'}
+        assert check_descriptor_length(descriptors, 1)
+
     def test_subset_descriptor(self):
         import numpy as np
         from pyrsa.util.descriptor_utils import subset_descriptor


### PR DESCRIPTION
check_descriptor_length casts each descriptor value to np.array. This can result in 0-d arrays if the input is str. The subsequent check on shape[0] then triggers an exception because 0-d arrays are weird and have no shape elements.

So I fixed that by flattening the array whenever the shape is empty. I also added a test.

Finally, I snuck in a stylistic change - single character variable names are rarely a good idea, and when the character clashes with a common pdb shortcut it's really ill advised.