### PR TITLE
Store descriptors as arrays (instead of as lists) in RDMs

### DIFF
--- a/pyrsa/data/computations.py
+++ b/pyrsa/data/computations.py
@@ -35,4 +35,4 @@ def average_dataset_by(dataset, by):
     descriptor = [d.obs_descriptors[by][0] for d in datasets]
     average = [average_dataset(d) for d in datasets]
     n_obs = [d.n_obs for d in datasets]
-    return np.array(average), descriptor, n_obs
+    return np.array(average), np.array(descriptor), np.array(n_obs)


### PR DESCRIPTION
Summary: Store descriptors as arrays (instead of as lists) in RDMs, so they can be indexed into by the `rdms.reorder` method.

I noticed that `calc_rdm` converts conditions that have `numpy` array values into lists. This appears to happen within `pyrsa.data.computations`:`average_dataset_by`. Seems better to keep everything as a numpy array instead of as a list.

Steps to replicate:
```python
import pyrsa
import numpy as np
import string

nChannel = 50
nObs = 10

# Choose some random letters as our 'conditions'
conditions = np.array(['a', 'a', 'b', 'b', 'c', 'c', 'd', 'd', 'e', 'e'])

obs_des = {'condition' : conditions}
measurements = np.random.rand(nObs, nChannel)

# Create a pyrsa dataset
data = pyrsa.data.Dataset(measurements,
                          obs_descriptors=obs_des)
# By default, the RDM will sort the conditions
rdms = pyrsa.rdm.calc_rdm(data, method='crossnobis', descriptor='condition')

# But perhaps I want the display order to be different
new_order = np.array([0, 4, 2, 1, 3])
rdms.reorder(new_order)

print(rdms)
```
Current output:
```python
Traceback (most recent call last):
  File "quick_test.py", line 22, in <module>
    rdms.reorder(new_order)
  File "/home/charles/Development/pyrsa/pyrsa/rdm/rdms.py", line 354, in reorder
    self.pattern_descriptors[dname] = descriptors[new_order]
TypeError: only integer scalar arrays can be converted to a scalar index
```
Expected output (aside from randomness in `dissimilarities`):
```
pyrsa.rdm.RDMs
1 RDM(s) over 5 conditions

dissimilarity_measure = 
crossnobis

dissimilarities[0] = 
[[ 0.         -2.08915991 -0.25144165 -1.35402033  0.08449471]
 [-2.08915991  0.          0.77741299 -1.80890735 -1.52122028]
 [-0.25144165  0.77741299  0.         -1.2876551  -2.62451962]
 [-1.35402033 -1.80890735 -1.2876551   0.         -1.27272867]
 [ 0.08449471 -1.52122028 -2.62451962 -1.27272867  0.        ]]

descriptors: 
noise = None
cv_descriptor = cv_desc

rdm_descriptors: 
index = [0]

pattern_descriptors: 
index = [0 4 2 1 3]
condition = ['a' 'e' 'c' 'b' 'd']
```

(Python 3.8, using latest `pyrsa` `master` branch)
Still new to this library, so let me know if this is incorrect usage.