### PR TITLE
Update rdms.reorder to assume descriptors is stored as a list

### DIFF
--- a/pyrsa/rdm/rdms.py
+++ b/pyrsa/rdm/rdms.py
@@ -186,7 +186,7 @@ class RDMs:
         Args:
             by(String): the descriptor by which the subset selection
                         is made from descriptors
-            value:      the value by which the subset selection is made
+            value:      the value(s) by which the subset selection is made
                         from descriptors
 
         Returns:
@@ -195,21 +195,18 @@ class RDMs:
         """
         if by is None:
             by = 'index'
+        desc = self.pattern_descriptors[by]  # desc is list-like
         if (
-                type(value) is list or
-                type(value) is tuple or
-                type(value) is np.ndarray):
-            desc = self.pattern_descriptors[by]
-            selection = [np.asarray(desc == i).nonzero()[0]
-                         for i in value]
-            selection = np.concatenate(selection)
+                isinstance(value, list) or
+                isinstance(value, tuple) or
+                isinstance(value, np.ndarray)):
+            selection = np.array([index for index, d in enumerate(desc) if d in value])
         else:
-            selection = np.where(self.rdm_descriptors[by] == value)
+            selection = np.array([index for index, d in enumerate(desc) if d == value])
         selection = np.sort(selection)
         dissimilarities = self.get_matrices()
         for i_rdm in range(self.n_rdm):
             np.fill_diagonal(dissimilarities[i_rdm], np.nan)
-        selection = np.sort(selection)
         dissimilarities = dissimilarities[:, selection][:, :, selection]
         descriptors = self.descriptors
         pattern_descriptors = extract_dict(
@@ -266,15 +263,14 @@ class RDMs:
         """
         if by is None:
             by = 'index'
+        desc = self.rdm_descriptors[by]
         if (
-                type(value) is list or
-                type(value) is tuple or
-                type(value) is np.ndarray):
-            selection = [np.asarray(self.rdm_descriptors[by] == i).nonzero()[0]
-                         for i in value]
-            selection = np.concatenate(selection)
+                isinstance(value, list) or
+                isinstance(value, tuple) or
+                isinstance(value, np.ndarray)):
+            selection = np.array([index for index, d in enumerate(desc) if d in value])
         else:
-            selection = np.where(self.rdm_descriptors[by] == value)
+            selection = np.array([index for index, d in enumerate(desc) if d == value])
         dissimilarities = self.dissimilarities[selection, :]
         descriptors = self.descriptors
         pattern_descriptors = self.pattern_descriptors

--- a/pyrsa/rdm/rdms.py
+++ b/pyrsa/rdm/rdms.py
@@ -351,7 +351,7 @@ class RDMs:
         matrices = matrices[(slice(None),) + np.ix_(new_order, new_order)]
         self.dissimilarities = batch_to_vectors(matrices)[0]
         for dname, descriptors in self.pattern_descriptors.items():
-            self.pattern_descriptors[dname] = descriptors[new_order]
+            self.pattern_descriptors[dname] = [descriptors[idx] for idx in new_order]
 
     def sort_by(self, **kwargs):
         """Reorder the patterns by sorting a descriptor


### PR DESCRIPTION
An alternate solution to fix the indexing problem in https://github.com/rsagroup/pyrsa/pull/140 . Some discussion there on whether it would be better to store `descriptors` text as a `list` or `np.array`.

Steps to replicate:
```python
import pyrsa
import numpy as np
import string

nChannel = 50
nObs = 10

# Choose some random letters as our 'conditions'
conditions = np.array(['a', 'a', 'b', 'b', 'c', 'c', 'd', 'd', 'e', 'e'])

obs_des = {'condition' : conditions}
measurements = np.random.rand(nObs, nChannel)

# Create a pyrsa dataset
data = pyrsa.data.Dataset(measurements,
                          obs_descriptors=obs_des)
# By default, the RDM will sort the conditions
rdms = pyrsa.rdm.calc_rdm(data, method='crossnobis', descriptor='condition')

# But perhaps I want the display order to be different
new_order = np.array([0, 4, 2, 1, 3])
rdms.reorder(new_order)

print(rdms)
```
Current output:
```python
Traceback (most recent call last):
  File "quick_test.py", line 22, in <module>
    rdms.reorder(new_order)
  File "/home/charles/Development/pyrsa/pyrsa/rdm/rdms.py", line 354, in reorder
    self.pattern_descriptors[dname] = descriptors[new_order]
TypeError: only integer scalar arrays can be converted to a scalar index
```
Expected output (aside from randomness in `dissimilarities`):
```
pyrsa.rdm.RDMs
1 RDM(s) over 5 conditions

dissimilarity_measure = 
crossnobis

dissimilarities[0] = 
[[ 0.         -2.08915991 -0.25144165 -1.35402033  0.08449471]
 [-2.08915991  0.          0.77741299 -1.80890735 -1.52122028]
 [-0.25144165  0.77741299  0.         -1.2876551  -2.62451962]
 [-1.35402033 -1.80890735 -1.2876551   0.         -1.27272867]
 [ 0.08449471 -1.52122028 -2.62451962 -1.27272867  0.        ]]

descriptors: 
noise = None
cv_descriptor = cv_desc

rdm_descriptors: 
index = [0]

pattern_descriptors: 
index = [0 4 2 1 3]
condition = ['a' 'e' 'c' 'b' 'd']
```

(Python 3.8, using latest `pyrsa` `master` branch)