### PR TITLE
Add colorbar option to show_rdm (default=False)

### DIFF
--- a/pyrsa/vis/rdm_plot.py
+++ b/pyrsa/vis/rdm_plot.py
@@ -11,7 +11,7 @@ from pyrsa.vis.colors import rdm_colormap
 
 
 def show_rdm(rdm, do_rank_transform=False, pattern_descriptor=None,
-             cmap=None, rdm_descriptor=None):
+             cmap=None, show_colorbar=False, rdm_descriptor=None):
     """shows an rdm object
 
     Parameters
@@ -27,6 +27,8 @@ def show_rdm(rdm, do_rank_transform=False, pattern_descriptor=None,
     cmap : color map
         colormap or identifier for a colormap to be used
         conventions as for matplotlib colormaps
+    show_colorbar : bool
+        whether to display a colorbar next to each RDM
 
     """
     if cmap is None:
@@ -39,19 +41,25 @@ def show_rdm(rdm, do_rank_transform=False, pattern_descriptor=None,
         n = np.ceil((1 + rdm.n_rdm) / m)
         for idx in range(rdm.n_rdm):
             plt.subplot(n, m, idx + 1)
-            plt.imshow(rdm_mat[idx], cmap=cmap)
+            image = plt.imshow(rdm_mat[idx], cmap=cmap)
             _add_descriptor_labels(rdm, pattern_descriptor)
             if rdm_descriptor:
                 plt.title(rdm.rdm_descriptors[rdm_descriptor][idx])
+            if show_colorbar:
+                plt.colorbar(image)
         plt.subplot(n, m, n * m)
-        plt.imshow(np.mean(rdm_mat, axis=0), cmap=cmap)
+        image = plt.imshow(np.mean(rdm_mat, axis=0), cmap=cmap)
         _add_descriptor_labels(rdm, pattern_descriptor)
         plt.title('Average')
+        if show_colorbar:
+            plt.colorbar(image)
     elif rdm.n_rdm == 1:
-        plt.imshow(rdm_mat[0], cmap=cmap)
+        image = plt.imshow(rdm_mat[0], cmap=cmap)
         _add_descriptor_labels(rdm, pattern_descriptor)
         if rdm_descriptor:
             plt.title(rdm.rdm_descriptors[rdm_descriptor][0])
+        if show_colorbar:
+            plt.colorbar(image)
     plt.show()
 
 


### PR DESCRIPTION
Standard usage (same as before) and output:
```
pyrsa.vis.show_rdm(model_rdms,
                   cmap='viridis',
                   pattern_descriptor='condition')
```
![image](https://user-images.githubusercontent.com/3221512/96166752-4137db00-0ed3-11eb-8b16-73b926b904db.png)


Example usage (new) with colorbar:
```
pyrsa.vis.show_rdm(model_rdms,
                   cmap='viridis',
                   pattern_descriptor='condition',
                   show_colorbar=True)
```
![image](https://user-images.githubusercontent.com/3221512/96166762-45fc8f00-0ed3-11eb-9038-fb142670803b.png)

`show_colorbar` defaults to `False` to keep the same default behavior as before (ie, no colorbar).