### PR TITLE
Normalize crossnobis distance by number of channels and fold-iterations

### DIFF
--- a/pyrsa/rdm/calc.py
+++ b/pyrsa/rdm/calc.py
@@ -297,7 +297,7 @@ def calc_rdm_crossnobis(dataset, descriptor, noise=None,
     dataset.sort_by(descriptor)
     cv_folds = np.unique(np.array(dataset.obs_descriptors[cv_descriptor]))
     rdms = []
-    if noise is None or (isinstance(noise, np.ndarray) and noise.ndim == 2):
+    if (noise is None) or (isinstance(noise, np.ndarray) and noise.ndim == 2):
         for i_fold in range(len(cv_folds)):
             fold = cv_folds[i_fold]
             data_test = dataset.subset_obs(cv_descriptor, fold)
@@ -307,7 +307,7 @@ def calc_rdm_crossnobis(dataset, descriptor, noise=None,
                 average_dataset_by(data_train, descriptor)
             measurements_test, _, _ = \
                 average_dataset_by(data_test, descriptor)
-            n_cond = measurements_train.shape[0]
+            n_cond, n_channel = measurements_train.shape
             rdm = np.empty(int(n_cond * (n_cond-1) / 2))
             k = 0
             for i_cond in range(n_cond - 1):
@@ -339,7 +339,7 @@ def calc_rdm_crossnobis(dataset, descriptor, noise=None,
                                       + variances[j_fold]))
                     rdms.append(rdm)
     rdms = np.array(rdms)
-    rdm = np.einsum('ij->j', rdms) / len(cv_folds)
+    rdm = rdms.mean(axis=0)
     rdm = RDMs(dissimilarities=np.array([rdm]),
                dissimilarity_measure='crossnobis',
                rdm_descriptors=deepcopy(dataset.descriptors))

--- a/pyrsa/rdm/calc.py
+++ b/pyrsa/rdm/calc.py
@@ -308,7 +308,6 @@ def calc_rdm_crossnobis(dataset, descriptor, noise=None,
             measurements_test, _, _ = \
                 average_dataset_by(data_test, descriptor)
             n_cond = measurements_train.shape[0]
-            n_channel = measurements_train.shape[1]
             rdm = np.empty(int(n_cond * (n_cond-1) / 2))
             k = 0
             for i_cond in range(n_cond - 1):

--- a/pyrsa/rdm/calc.py
+++ b/pyrsa/rdm/calc.py
@@ -326,15 +326,19 @@ def calc_rdm_crossnobis(dataset, descriptor, noise=None,
             rdms.append(rdm)
     else:  # a list of noises was provided
         measurements = []
+        variances = []
         for i_fold in range(len(cv_folds)):
             data = dataset.subset_obs(cv_descriptor, cv_folds[i_fold])
             measurements.append(average_dataset_by(data, descriptor)[0])
+            variances.append(np.linalg.inv(noise[i_fold]))
         for i_fold in range(len(cv_folds)):
-            for j_fold in range(len(cv_folds)):
+            for j_fold in range(i_fold + 1, len(cv_folds)):
                 if i_fold != j_fold:
                     rdm = _calc_rdm_crossnobis_single(
                         measurements[i_fold], measurements[j_fold],
-                        noise[i_fold])
+                        np.linalg.inv(
+                            (variances[i_fold] + variances[j_fold]) / 2)
+                        )
                     rdms.append(rdm)
     rdms = np.array(rdms)
     rdm = rdms.mean(axis=0)

--- a/pyrsa/rdm/calc.py
+++ b/pyrsa/rdm/calc.py
@@ -307,7 +307,8 @@ def calc_rdm_crossnobis(dataset, descriptor, noise=None,
                 average_dataset_by(data_train, descriptor)
             measurements_test, _, _ = \
                 average_dataset_by(data_test, descriptor)
-            n_cond, n_channel = measurements_train.shape
+            n_cond = measurements_train.shape[0]
+            n_channel = measurements_train.shape[1]
             rdm = np.empty(int(n_cond * (n_cond-1) / 2))
             k = 0
             for i_cond in range(n_cond - 1):
@@ -325,18 +326,15 @@ def calc_rdm_crossnobis(dataset, descriptor, noise=None,
             rdms.append(rdm)
     else:  # a list of noises was provided
         measurements = []
-        variances = []
         for i_fold in range(len(cv_folds)):
             data = dataset.subset_obs(cv_descriptor, cv_folds[i_fold])
             measurements.append(average_dataset_by(data, descriptor)[0])
-            variances.append(np.linalg.inv(noise[i_fold]))
         for i_fold in range(len(cv_folds)):
-            for j_fold in range(i_fold + 1, len(cv_folds)):
+            for j_fold in range(len(cv_folds)):
                 if i_fold != j_fold:
                     rdm = _calc_rdm_crossnobis_single(
                         measurements[i_fold], measurements[j_fold],
-                        np.linalg.inv(variances[i_fold]
-                                      + variances[j_fold]))
+                        noise[i_fold])
                     rdms.append(rdm)
     rdms = np.array(rdms)
     rdm = rdms.mean(axis=0)


### PR DESCRIPTION
To match the documentation,
![image](https://user-images.githubusercontent.com/3221512/104658131-0599e200-5677-11eb-956a-865aecb2c1ab.png)
the crossnobis sum should be divided by the number of channels `P` and the number of iterations `M-choose-2`.

Note: `_calc_crossnobis_single`, which is used if a list of noises is provided, does already normalize by the number of channels: https://github.com/rsagroup/pyrsa/blob/master/pyrsa/rdm/calc.py#L443

This change causes the crossnobis distance to match the scaling of mahalanobis distance.