### PR TITLE
bugfix: batch_to_vectors returns a tuple where the first entry is the RDM

### DIFF
--- a/pyrsa/model/model.py
+++ b/pyrsa/model/model.py
@@ -105,8 +105,7 @@ class ModelFixed(Model):
             self.rdm = rdm
         else:  # User passed a matrix
             self.rdm_obj = RDMs(np.array([rdm]))
-            self.rdm = batch_to_vectors(np.array([rdm]))[0]
-            self.n_cond = self.rdm_obj.n_cond
+            self.rdm, _, self.n_cond = batch_to_vectors(np.array([rdm]))[0]
         self.n_param = 0
         self.default_fitter = fit_mock
         self.rdm_obj.pattern_descriptors['index'] = np.arange(self.n_cond)
@@ -162,7 +161,7 @@ class ModelSelect(Model):
             self.rdm = rdm
         else:  # User passed matrixes
             self.rdm_obj = RDMs(rdm)
-            self.rdm = batch_to_vectors(rdm)
+            self.rdm, _, _ = batch_to_vectors(rdm)
         self.n_param = 1
         self.n_rdm = self.rdm_obj.n_rdm
         self.default_fitter = fit_select
@@ -217,7 +216,7 @@ class ModelWeighted(Model):
             self.rdm = rdm
         else:  # User passed matrixes
             self.rdm_obj = RDMs(rdm)
-            self.rdm = batch_to_vectors(rdm)
+            self.rdm, _, _ = batch_to_vectors(rdm)
         self.n_param = self.rdm_obj.n_rdm
         self.n_rdm = self.rdm_obj.n_rdm
         self.default_fitter = fit_optimize
@@ -285,7 +284,7 @@ class ModelInterpolate(Model):
             self.rdm = rdm
         else:  # User passed matrixes
             self.rdm_obj = RDMs(rdm)
-            self.rdm = batch_to_vectors(rdm)
+            self.rdm, _, _ = batch_to_vectors(rdm)
         self.n_param = self.rdm_obj.n_rdm
         self.n_rdm = self.rdm_obj.n_rdm
         self.default_fitter = fit_interpolate


### PR DESCRIPTION
Only the 0-index of the return value is the RDM, so the caller should assign only that value to `self.rdm`

See https://github.com/charlesincharge/pyrsa/blob/a80cd1d8d7363d9b882c56cf8e869fca17c81ce9/pyrsa/util/rdm_utils.py#L40 , i.e.
```python
    return v, n_rdm, n_cond
```