### PR TITLE
speed update for calc_rdm

### DIFF
--- a/pyrsa/rdm/calc.py
+++ b/pyrsa/rdm/calc.py
@@ -84,9 +84,10 @@ def calc_rdm(dataset, method='euclidean', descriptor=None, noise=None,
     return rdm
 
 
-def calc_rdm_movie(dataset, method='euclidean', descriptor=None, noise=None,
-             cv_descriptor=None, prior_lambda=1, prior_weight=0.1,
-             time_descriptor='time', bins=None):
+def calc_rdm_movie(
+        dataset, method='euclidean', descriptor=None, noise=None,
+        cv_descriptor=None, prior_lambda=1, prior_weight=0.1,
+        time_descriptor='time', bins=None):
     """
     calculates an RDM movie from an input TemporalDataset
 
@@ -154,24 +155,21 @@ def calc_rdm_movie(dataset, method='euclidean', descriptor=None, noise=None,
 
 def calc_rdm_euclid(dataset, descriptor=None):
     """
-    calculates an RDM from an input dataset using euclidean distance
-    If multiple instances of the same condition are found in the dataset
-    they are averaged.
-
     Args:
         dataset (pyrsa.data.DatasetBase):
             The dataset the RDM is computed from
         descriptor (String):
             obs_descriptor used to define the rows/columns of the RDM
             defaults to one row/column per row in the dataset
-
     Returns:
         pyrsa.rdm.rdms.RDMs: RDMs object with the one RDM
-
     """
+
     measurements, desc, descriptor = _parse_input(dataset, descriptor)
-    diff = _calc_pairwise_differences(measurements)
-    rdm = np.einsum('ij,ij->i', diff, diff) / measurements.shape[1]
+    sum_sq_measurements = np.sum(measurements**2, axis=1, keepdims=True)
+    rdm = sum_sq_measurements + sum_sq_measurements.T \
+        - 2 * np.dot(measurements, measurements.T)
+    rdm = _extract_triu_(rdm) / measurements.shape[1]
     rdm = RDMs(dissimilarities=np.array([rdm]),
                dissimilarity_measure='euclidean',
                rdm_descriptors=deepcopy(dataset.descriptors))
@@ -233,14 +231,12 @@ def calc_rdm_mahalanobis(dataset, descriptor=None, noise=None):
     else:
         measurements, desc, descriptor = _parse_input(dataset, descriptor)
         noise = _check_noise(noise, dataset.n_channel)
-        # calculate difference @ precision @ difference for all pairs
-        # first calculate the difference vectors diff and precision @ diff
-        # then calculate the inner product
-        diff = _calc_pairwise_differences(measurements)
-        diff2 = (noise @ diff.T).T
-        rdm = np.einsum('ij,ij->i', diff, diff2) / measurements.shape[1]
+        kernel = measurements @ noise @ measurements.T
+        rdm = np.expand_dims(np.diag(kernel), 0) + np.expand_dims(np.diag(kernel), 1)\
+            - 2 * kernel
+        rdm = _extract_triu_(rdm) / measurements.shape[1]
         rdm = RDMs(dissimilarities=np.array([rdm]),
-                   dissimilarity_measure='Mahalanobis',
+                   dissimilarity_measure='euclidean',
                    rdm_descriptors=deepcopy(dataset.descriptors))
         rdm.pattern_descriptors[descriptor] = desc
         rdm.descriptors['noise'] = noise
@@ -287,6 +283,8 @@ def calc_rdm_crossnobis(dataset, descriptor, noise=None,
 
     """
     noise = _check_noise(noise, dataset.n_channel)
+    if noise is None:
+        noise = np.eye(dataset.n_channel)
     if descriptor is None:
         raise ValueError('descriptor must be a string! Crossvalidation' +
                          'requires multiple measurements to be grouped')
@@ -307,21 +305,8 @@ def calc_rdm_crossnobis(dataset, descriptor, noise=None,
                 average_dataset_by(data_train, descriptor)
             measurements_test, _, _ = \
                 average_dataset_by(data_test, descriptor)
-            n_cond = measurements_train.shape[0]
-            rdm = np.empty(int(n_cond * (n_cond-1) / 2))
-            k = 0
-            for i_cond in range(n_cond - 1):
-                for j_cond in range(i_cond + 1, n_cond):
-                    diff_train = measurements_train[i_cond] \
-                        - measurements_train[j_cond]
-                    diff_test = measurements_test[i_cond] \
-                        - measurements_test[j_cond]
-                    if noise is None:
-                        rdm[k] = np.mean(diff_train * diff_test)
-                    else:
-                        rdm[k] = np.mean(diff_train
-                                         * np.matmul(noise, diff_test))
-                    k += 1
+            rdm = _calc_rdm_crossnobis_single(
+                measurements_train, measurements_test, noise)
             rdms.append(rdm)
     else:  # a list of noises was provided
         measurements = []
@@ -332,14 +317,13 @@ def calc_rdm_crossnobis(dataset, descriptor, noise=None,
             variances.append(np.linalg.inv(noise[i_fold]))
         for i_fold in range(len(cv_folds)):
             for j_fold in range(i_fold + 1, len(cv_folds)):
-                if i_fold != j_fold:
-                    rdm = _calc_rdm_crossnobis_single(
-                        measurements[i_fold], measurements[j_fold],
-                        np.linalg.inv(variances[i_fold]
-                                      + variances[j_fold]))
-                    rdms.append(rdm)
+                rdm = _calc_rdm_crossnobis_single(
+                    measurements[i_fold], measurements[j_fold],
+                    np.linalg.inv(variances[i_fold]
+                                  + variances[j_fold]))
+                rdms.append(rdm)
     rdms = np.array(rdms)
-    rdm = np.einsum('ij->j', rdms) / len(cv_folds)
+    rdm = np.einsum('ij->j', rdms) / rdms.shape[0]
     rdm = RDMs(dissimilarities=np.array([rdm]),
                dissimilarity_measure='crossnobis',
                rdm_descriptors=deepcopy(dataset.descriptors))
@@ -372,9 +356,10 @@ def calc_rdm_poisson(dataset, descriptor=None, prior_lambda=1,
     measurements, desc, descriptor = _parse_input(dataset, descriptor)
     measurements = (measurements + prior_lambda * prior_weight) \
         / (1 + prior_weight)
-    diff = _calc_pairwise_differences(measurements)
-    diff_log = _calc_pairwise_differences(np.log(measurements))
-    rdm = np.einsum('ij,ij->i', diff, diff_log) / measurements.shape[1]
+    kernel = measurements @ np.log(measurements).T
+    rdm = np.expand_dims(np.diag(kernel), 0) + np.expand_dims(np.diag(kernel), 1)\
+        - kernel - kernel.T
+    rdm = _extract_triu_(rdm) / measurements.shape[1]
     rdm = RDMs(dissimilarities=np.array([rdm]),
                dissimilarity_measure='poisson',
                rdm_descriptors=deepcopy(dataset.descriptors))
@@ -427,10 +412,10 @@ def calc_rdm_poisson_cv(dataset, descriptor=None, prior_lambda=1,
         measurements_test = (measurements_test
                              + prior_lambda * prior_weight) \
             / (1 + prior_weight)
-        diff = _calc_pairwise_differences(measurements_train)
-        diff_log = _calc_pairwise_differences(np.log(measurements_test))
-        rdm = np.einsum('ij,ij->i', diff, diff_log) \
-            / measurements_train.shape[1]
+        kernel = measurements_train @ np.log(measurements_test).T
+        rdm = np.expand_dims(np.diag(kernel), 0) + np.expand_dims(np.diag(kernel), 1)\
+            - kernel - kernel.T
+        rdm = _extract_triu_(rdm) / measurements_train.shape[1]
     rdm = RDMs(dissimilarities=np.array([rdm]),
                dissimilarity_measure='poisson_cv',
                rdm_descriptors=deepcopy(dataset.descriptors))
@@ -439,21 +424,11 @@ def calc_rdm_poisson_cv(dataset, descriptor=None, prior_lambda=1,
     return rdm
 
 
-def _calc_rdm_crossnobis_single_sparse(measurements1, measurements2, noise):
-    c_matrix = pairwise_contrast_sparse(np.arange(measurements1.shape[0]))
-    diff_1 = c_matrix @ measurements1
-    diff_2 = c_matrix @ measurements2
-    diff_2 = noise @ diff_2.transpose()
-    rdm = np.einsum('kj,jk->k', diff_1, diff_2) / measurements1.shape[1]
-    return rdm
-
-
 def _calc_rdm_crossnobis_single(measurements1, measurements2, noise):
-    diff_1 = _calc_pairwise_differences(measurements1)
-    diff_2 = _calc_pairwise_differences(measurements2)
-    diff_2 = noise @ diff_2.transpose()
-    rdm = np.einsum('kj,jk->k', diff_1, diff_2) / measurements1.shape[1]
-    return rdm
+    kernel = measurements1 @ noise @ measurements2.T
+    rdm = np.expand_dims(np.diag(kernel), 0) + np.expand_dims(np.diag(kernel), 1)\
+        - kernel - kernel.T
+    return _extract_triu_(rdm) / measurements1.shape[1]
 
 
 def _gen_default_cv_descriptor(dataset, descriptor):
@@ -519,3 +494,8 @@ def _check_noise(noise, n_channel):
     else:
         raise ValueError('noise(s) must have shape n_channel x n_channel')
     return noise
+
+
+def _extract_triu_(X):
+    mask = np.triu(np.ones_like(X, dtype=bool), k=1)
+    return X[mask]

--- a/pyrsa/rdm/calc.py
+++ b/pyrsa/rdm/calc.py
@@ -236,7 +236,7 @@ def calc_rdm_mahalanobis(dataset, descriptor=None, noise=None):
             - 2 * kernel
         rdm = _extract_triu_(rdm) / measurements.shape[1]
         rdm = RDMs(dissimilarities=np.array([rdm]),
-                   dissimilarity_measure='euclidean',
+                   dissimilarity_measure='mahalanobis',
                    rdm_descriptors=deepcopy(dataset.descriptors))
         rdm.pattern_descriptors[descriptor] = desc
         rdm.descriptors['noise'] = noise

--- a/pyrsa/rdm/calc.py
+++ b/pyrsa/rdm/calc.py
@@ -11,7 +11,7 @@ import numpy as np
 from pyrsa.rdm.rdms import RDMs
 from pyrsa.rdm.rdms import concat
 from pyrsa.data import average_dataset_by
-from pyrsa.util.matrix import pairwise_contrast_sparse
+from pyrsa.util.rdm_utils import _extract_triu_
 
 
 def calc_rdm(dataset, method='euclidean', descriptor=None, noise=None,
@@ -494,8 +494,3 @@ def _check_noise(noise, n_channel):
     else:
         raise ValueError('noise(s) must have shape n_channel x n_channel')
     return noise
-
-
-def _extract_triu_(X):
-    mask = np.triu(np.ones_like(X, dtype=bool), k=1)
-    return X[mask]

--- a/pyrsa/util/rdm_utils.py
+++ b/pyrsa/util/rdm_utils.py
@@ -110,3 +110,17 @@ def add_pattern_index(rdms, pattern_descriptor):
     pattern_select = rdms.pattern_descriptors[pattern_descriptor]
     pattern_select = np.unique(pattern_select)
     return pattern_descriptor, pattern_select
+
+
+def _extract_triu_(X):
+    """ extracts the upper triangular vector as a masked view
+
+    Args:
+        X (numpy.ndarray): 2D symmetric matrix
+
+    Returns:
+        vector version of X
+
+    """
+    mask = np.triu(np.ones_like(X, dtype=bool), k=1)
+    return X[mask]

--- a/tests/test_calc_rdm.py
+++ b/tests/test_calc_rdm.py
@@ -270,16 +270,19 @@ class TestCalcRDMMovie(unittest.TestCase):
         assert rdm.rdm_descriptors['time'][0] == 0.0
 
     def test_calc_rdm_movie_crossnobis_no_descriptors(self):
-        rdm = rsr.calc_rdm_crossnobis(self.test_data_time_balanced,
-                                      descriptor='conds')
+        rdm = rsr.calc_rdm_movie(
+            self.test_data_time_balanced,
+            method='crossnobis', time_descriptor='time',
+            descriptor='conds')
         assert rdm.n_cond == 5
 
     def test_calc_rdm_movie_crossnobis_noise(self):
         noise = np.random.randn(10, 5)
         noise = np.matmul(noise.T, noise)
-        rdm = rsr.calc_rdm_crossnobis(self.test_data_time_balanced,
-                                      descriptor='conds',
-                                      noise=noise)
+        rdm = rsr.calc_rdm_movie(
+            self.test_data_time_balanced,
+            method='crossnobis', time_descriptor='time',
+            descriptor='conds', noise=noise)
         assert rdm.n_cond == 5
 
     def test_calc_rdm_movie_rdm_movie_poisson(self):

--- a/tests/test_calc_rdm.py
+++ b/tests/test_calc_rdm.py
@@ -127,6 +127,10 @@ class TestCalcRDM(unittest.TestCase):
         rdm = rsr.calc_rdm(self.test_data, descriptor='conds',
                            method='mahalanobis')
         assert rdm.n_cond == 6
+        noise = np.linalg.inv(np.cov(np.random.randn(10, 5).T))
+        rdm = rsr.calc_rdm(self.test_data, descriptor='conds',
+                           method='mahalanobis', noise=noise)
+        assert rdm.n_cond == 6
 
     def test_calc_crossnobis(self):
         rdm = rsr.calc_rdm_crossnobis(self.test_data,


### PR DESCRIPTION
As @Tal-Golan  noticed, we had a large performance problem for calculating RDMs in the first place.
The vectorized solution which calculates the kernel/inner product first is MUCH faster. I switched all calc_rdm functions to this method here.

closes #181 