### PR TITLE
Fix nan

### DIFF
--- a/rsatoolbox/inference/evaluate.py
+++ b/rsatoolbox/inference/evaluate.py
@@ -229,7 +229,7 @@ def dual_bootstrap(models, data, method='cosine', fitter=None,
     return result
 
 
-def eval_fixed(models, data, theta=None, method='cosine'):
+def eval_fixed(models, data, theta=None, method='cosine', returnNaN=False):
     """evaluates models on data, without any bootstrapping or
     cross-validation
 
@@ -248,7 +248,7 @@ def eval_fixed(models, data, theta=None, method='cosine'):
                             data.n_rdm, -1)
     for k, model in enumerate(models):
         rdm_pred = model.predict_rdm(theta=theta[k])
-        evaluations[k] = compare(rdm_pred, data, method)
+        evaluations[k] = compare(rdm_pred, data, method, returnNaN)
     evaluations = evaluations.reshape((1, len(models), data.n_rdm))
     noise_ceil = boot_noise_ceiling(
         data, method=method, rdm_descriptor='index')
@@ -263,7 +263,7 @@ def eval_fixed(models, data, theta=None, method='cosine'):
 
 def eval_bootstrap(models, data, theta=None, method='cosine', N=1000,
                    pattern_descriptor='index', rdm_descriptor='index',
-                   boot_noise_ceil=True):
+                   boot_noise_ceil=True, returnNaN=False):
     """evaluates models on data
     performs bootstrapping to get a sampling distribution
 
@@ -294,7 +294,7 @@ def eval_bootstrap(models, data, theta=None, method='cosine', N=1000,
                 rdm_pred = rdm_pred.subsample_pattern(pattern_descriptor,
                                                       pattern_idx)
                 evaluations[i, j] = np.mean(compare(rdm_pred, sample,
-                                                    method))
+                                                    method, returnNaN))
             if boot_noise_ceil:
                 noise_min_sample, noise_max_sample = boot_noise_ceiling(
                     sample, method=method, rdm_descriptor=rdm_descriptor)
@@ -323,7 +323,7 @@ def eval_bootstrap(models, data, theta=None, method='cosine', N=1000,
 
 def eval_bootstrap_pattern(models, data, theta=None, method='cosine', N=1000,
                            pattern_descriptor='index', rdm_descriptor='index',
-                           boot_noise_ceil=True):
+                           boot_noise_ceil=True, returnNaN=False):
     """evaluates a models on data
     performs bootstrapping over patterns to get a sampling distribution
 
@@ -354,7 +354,7 @@ def eval_bootstrap_pattern(models, data, theta=None, method='cosine', N=1000,
                 rdm_pred = rdm_pred.subsample_pattern(pattern_descriptor,
                                                       pattern_idx)
                 evaluations[i, j] = np.mean(compare(rdm_pred, sample,
-                                                    method))
+                                                    method, returnNaN))
             if boot_noise_ceil:
                 noise_min_sample, noise_max_sample = boot_noise_ceiling(
                     sample, method=method, rdm_descriptor=rdm_descriptor)
@@ -382,7 +382,7 @@ def eval_bootstrap_pattern(models, data, theta=None, method='cosine', N=1000,
 
 
 def eval_bootstrap_rdm(models, data, theta=None, method='cosine', N=1000,
-                       rdm_descriptor='index', boot_noise_ceil=True):
+                       rdm_descriptor='index', boot_noise_ceil=True, returnNaN=False):
     """evaluates models on data
     performs bootstrapping to get a sampling distribution
 
@@ -406,7 +406,7 @@ def eval_bootstrap_rdm(models, data, theta=None, method='cosine', N=1000,
         for j, mod in enumerate(models):
             rdm_pred = mod.predict_rdm(theta=theta[j])
             evaluations[i, j] = np.mean(compare(rdm_pred, sample,
-                                                method))
+                                                method, returnNaN))
         if boot_noise_ceil:
             noise_min_sample, noise_max_sample = boot_noise_ceiling(
                 sample, method=method, rdm_descriptor=rdm_descriptor)
@@ -431,7 +431,7 @@ def eval_bootstrap_rdm(models, data, theta=None, method='cosine', N=1000,
 
 
 def crossval(models, rdms, train_set, test_set, ceil_set=None, method='cosine',
-             fitter=None, pattern_descriptor='index', calc_noise_ceil=True):
+             fitter=None, pattern_descriptor='index', calc_noise_ceil=True, returnNaN=False):
     """evaluates models on cross-validation sets
 
     Args:
@@ -473,7 +473,7 @@ def crossval(models, rdms, train_set, test_set, ceil_set=None, method='cosine',
                 pred = model.predict_rdm(theta)
                 pred = pred.subsample_pattern(by=pattern_descriptor,
                                               value=test[1])
-                evals[j] = np.mean(compare(pred, test[0], method))
+                evals[j] = np.mean(compare(pred, test[0], method, returnNaN))
             if ceil_set is None and calc_noise_ceil:
                 noise_ceil.append(boot_noise_ceiling(
                     rdms.subsample_pattern(by=pattern_descriptor,

--- a/rsatoolbox/rdm/compare.py
+++ b/rsatoolbox/rdm/compare.py
@@ -12,7 +12,7 @@ from rsatoolbox.util.rdm_utils import _get_n_from_length
 from rsatoolbox.util.matrix import row_col_indicator_g
 
 
-def compare(rdm1, rdm2, method='cosine', sigma_k=None):
+def compare(rdm1, rdm2, method='cosine', sigma_k=None, returnNaN=False):
     """calculates the similarity between two RDMs objects using a chosen method
 
     Args:
@@ -45,33 +45,37 @@ def compare(rdm1, rdm2, method='cosine', sigma_k=None):
             covariance matrix of the pattern estimates.
             Used only for methods 'corr_cov' and 'cosine_cov'.
 
+        returnNaN :
+            If incompatible NaN's are found a NaN value is returned rather
+            than an error being raised
+
     Returns:
         numpy.ndarray: dist:
             pariwise similarities between the RDMs from the RDMs objects
 
     """
     if method == 'cosine':
-        sim = compare_cosine(rdm1, rdm2)
+        sim = compare_cosine(rdm1, rdm2, returnNaN)
     elif method == 'spearman':
-        sim = compare_spearman(rdm1, rdm2)
+        sim = compare_spearman(rdm1, rdm2, returnNaN)
     elif method == 'corr':
-        sim = compare_correlation(rdm1, rdm2)
+        sim = compare_correlation(rdm1, rdm2, returnNaN)
     elif method == 'kendall' or method == 'tau-b':
-        sim = compare_kendall_tau(rdm1, rdm2)
+        sim = compare_kendall_tau(rdm1, rdm2, returnNaN)
     elif method == 'tau-a':
-        sim = compare_kendall_tau_a(rdm1, rdm2)
+        sim = compare_kendall_tau_a(rdm1, rdm2, returnNaN)
     elif method == 'rho-a':
-        sim = compare_rho_a(rdm1, rdm2)
+        sim = compare_rho_a(rdm1, rdm2, returnNaN)
     elif method == 'corr_cov':
-        sim = compare_correlation_cov_weighted(rdm1, rdm2, sigma_k=sigma_k)
+        sim = compare_correlation_cov_weighted(rdm1, rdm2, sigma_k=sigma_k, returnNaN)
     elif method == 'cosine_cov':
-        sim = compare_cosine_cov_weighted(rdm1, rdm2, sigma_k=sigma_k)
+        sim = compare_cosine_cov_weighted(rdm1, rdm2, sigma_k=sigma_k, returnNaN)
     else:
         raise ValueError('Unknown RDM comparison method requested!')
     return sim
 
 
-def compare_cosine(rdm1, rdm2):
+def compare_cosine(rdm1, rdm2, returnNaN):
     """calculates the cosine similarities between two RDMs objects
 
     Args:
@@ -84,12 +88,14 @@ def compare_cosine(rdm1, rdm2):
             cosine similarity between the two RDMs
 
     """
-    vector1, vector2, _ = _parse_input_rdms(rdm1, rdm2)
+    vector1, vector2, _ = _parse_input_rdms(rdm1, rdm2, returnNaN)
+    if np.isnan(vector1):
+        return np.NaN
     sim = _cosine(vector1, vector2)
     return sim
 
 
-def compare_correlation(rdm1, rdm2):
+def compare_correlation(rdm1, rdm2, returnNaN):
     """calculates the correlations between two RDMs objects
 
     Args:
@@ -102,7 +108,9 @@ def compare_correlation(rdm1, rdm2):
             correlations between the two RDMs
 
     """
-    vector1, vector2, _ = _parse_input_rdms(rdm1, rdm2)
+    vector1, vector2, _ = _parse_input_rdms(rdm1, rdm2, returnNaN)
+    if np.isnan(vector1):
+        return np.NaN
     # compute by subtracting the mean and then calculating cosine similarity
     vector1 = vector1 - np.mean(vector1, 1, keepdims=True)
     vector2 = vector2 - np.mean(vector2, 1, keepdims=True)
@@ -110,7 +118,7 @@ def compare_correlation(rdm1, rdm2):
     return sim
 
 
-def compare_cosine_cov_weighted(rdm1, rdm2, sigma_k=None):
+def compare_cosine_cov_weighted(rdm1, rdm2, sigma_k=None, returnNaN):
     """calculates the cosine similarities between two RDMs objects
 
     Args:
@@ -123,12 +131,14 @@ def compare_cosine_cov_weighted(rdm1, rdm2, sigma_k=None):
             cosine similarities between the two RDMs
 
     """
-    vector1, vector2, nan_idx = _parse_input_rdms(rdm1, rdm2)
+    vector1, vector2, nan_idx = _parse_input_rdms(rdm1, rdm2, returnNaN)
+    if np.isnan(vector1):
+        return np.NaN
     sim = _cosine_cov_weighted(vector1, vector2, sigma_k, nan_idx)
     return sim
 
 
-def compare_correlation_cov_weighted(rdm1, rdm2, sigma_k=None):
+def compare_correlation_cov_weighted(rdm1, rdm2, sigma_k=None, returnNaN):
     """calculates the correlations between two RDMs objects after whitening
     with the covariance of the entries
 
@@ -143,7 +153,9 @@ def compare_correlation_cov_weighted(rdm1, rdm2, sigma_k=None):
             correlations between the two RDMs
 
     """
-    vector1, vector2, nan_idx = _parse_input_rdms(rdm1, rdm2)
+    vector1, vector2, nan_idx = _parse_input_rdms(rdm1, rdm2, returnNaN)
+    if np.isnan(vector1):
+        return np.NaN
     # compute by subtracting the mean and then calculating cosine similarity
     vector1 = vector1 - np.mean(vector1, 1, keepdims=True)
     vector2 = vector2 - np.mean(vector2, 1, keepdims=True)
@@ -151,7 +163,7 @@ def compare_correlation_cov_weighted(rdm1, rdm2, sigma_k=None):
     return sim
 
 
-def compare_spearman(rdm1, rdm2):
+def compare_spearman(rdm1, rdm2, returnNaN):
     """calculates the spearman rank correlations between
     two RDMs objects
 
@@ -165,7 +177,9 @@ def compare_spearman(rdm1, rdm2):
             rank correlations between the two RDMs
 
     """
-    vector1, vector2, _ = _parse_input_rdms(rdm1, rdm2)
+    vector1, vector2, _ = _parse_input_rdms(rdm1, rdm2, returnNaN)
+    if np.isnan(vector1):
+        return np.NaN
     vector1 = np.apply_along_axis(scipy.stats.rankdata, 1, vector1)
     vector2 = np.apply_along_axis(scipy.stats.rankdata, 1, vector2)
     vector1 = vector1 - np.mean(vector1, 1, keepdims=True)
@@ -174,7 +188,7 @@ def compare_spearman(rdm1, rdm2):
     return sim
 
 
-def compare_rho_a(rdm1, rdm2):
+def compare_rho_a(rdm1, rdm2, returnNaN):
     """calculates the spearman rank correlations between
     two RDMs objects without tie correction
 
@@ -188,7 +202,9 @@ def compare_rho_a(rdm1, rdm2):
             rank correlations between the two RDMs
 
     """
-    vector1, vector2, _ = _parse_input_rdms(rdm1, rdm2)
+    vector1, vector2, _ = _parse_input_rdms(rdm1, rdm2, returnNaN)
+    if np.isnan(vector1):
+        return np.NaN
     vector1 = np.apply_along_axis(scipy.stats.rankdata, 1, vector1)
     vector2 = np.apply_along_axis(scipy.stats.rankdata, 1, vector2)
     vector1 = vector1 - np.mean(vector1, 1, keepdims=True)
@@ -198,7 +214,7 @@ def compare_rho_a(rdm1, rdm2):
     return sim
 
 
-def compare_kendall_tau(rdm1, rdm2):
+def compare_kendall_tau(rdm1, rdm2, returnNaN):
     """calculates the Kendall-tau bs between two RDMs objects.
     Kendall-tau b is the version, which corrects for ties.
     We here use the implementation from scipy.
@@ -212,12 +228,14 @@ def compare_kendall_tau(rdm1, rdm2):
         numpy.ndarray: dist:
             kendall-tau correlation between the two RDMs
     """
-    vector1, vector2, _ = _parse_input_rdms(rdm1, rdm2)
+    vector1, vector2, _ = _parse_input_rdms(rdm1, rdm2, returnNaN)
+    if np.isnan(vector1):
+        return np.NaN
     sim = _all_combinations(vector1, vector2, _kendall_tau)
     return sim
 
 
-def compare_kendall_tau_a(rdm1, rdm2):
+def compare_kendall_tau_a(rdm1, rdm2, returnNaN):
     """calculates the Kendall-tau a based distance between two RDMs objects.
     adequate when some models predict ties
 
@@ -230,7 +248,9 @@ def compare_kendall_tau_a(rdm1, rdm2):
         numpy.ndarray: dist:
             kendall-tau a between the two RDMs
     """
-    vector1, vector2, _ = _parse_input_rdms(rdm1, rdm2)
+    vector1, vector2, _ = _parse_input_rdms(rdm1, rdm2, returnNaN)
+    if np.isnan(vector1):
+        return np.NaN
     sim = _all_combinations(vector1, vector2, _tau_a)
     return sim
 
@@ -517,7 +537,7 @@ def _get_v(n_cond, sigma_k):
     return v
 
 
-def _parse_input_rdms(rdm1, rdm2):
+def _parse_input_rdms(rdm1, rdm2, returnNaN=False):
     """Gets the vector representation of input RDMs, raises an error if
     the two RDMs objects have different dimensions
 
@@ -548,5 +568,8 @@ def _parse_input_rdms(rdm1, rdm2):
     vector1_no_nan = vector1[nan_idx].reshape(vector1.shape[0], -1)
     vector2_no_nan = vector2[~np.isnan(vector2)].reshape(vector2.shape[0], -1)
     if not vector1_no_nan.shape[1] == vector2_no_nan.shape[1]:
-        raise ValueError('rdm1 and rdm2 have different nan positions')
+        if returnNaN:
+            return np.NaN, np.NaN, np.NaN
+        else:
+            raise ValueError('rdm1 and rdm2 have different nan positions')
     return vector1_no_nan, vector2_no_nan, nan_idx[0]

--- a/rsatoolbox/util/searchlight.py
+++ b/rsatoolbox/util/searchlight.py
@@ -180,7 +180,7 @@ def get_searchlight_RDMs(data_2d, centers, neighbors, events,
     return SL_rdms
 
 
-def evaluate_models_searchlight(sl_RDM, models, eval_function, method='corr', theta=None, n_jobs=1):
+def evaluate_models_searchlight(sl_RDM, models, eval_function, method='corr', theta=None, n_jobs=1, returnNaN=False):
     """evaluates each searchlighth with the given model/models
 
     Args:
@@ -196,6 +196,8 @@ def evaluate_models_searchlight(sl_RDM, models, eval_function, method='corr', th
 
         n_jobs (int, optional): how many jobs to run. Defaults to 1.
 
+        returnNaN (bool, optional): return NaN for patches with incompatible NaN
+
     Returns:
 
         list: list of with the model evaluation for each searchlight center
@@ -203,7 +205,7 @@ def evaluate_models_searchlight(sl_RDM, models, eval_function, method='corr', th
 
     results = Parallel(n_jobs=n_jobs)(
         delayed(eval_function)(
-            models, x, method=method, theta=theta) for x in tqdm(
+            models, x, method=method, theta=theta, returnNaN) for x in tqdm(
             sl_RDM, desc='Evaluating models for each searchlight'))
 
     return results


### PR DESCRIPTION
So, not the prettiest, but I wasn't really sure of a better approach.

I added an option to the `_parse_input_rdms` that is to just return np.NaNs if their are incompatible NaNs. I then manually check if a NaN was returned in `vector1` and then if it was, just return NaN.

I also added this arguement into the functions that call `compare`, but I didn't update all documentation since it is an optional arguement, and truthfully, most people probably shouldn't use it unless they are doing searchlight analysis (where I did add it to the documentation)