### PR TITLE
Fixed Permute RDMs function

### DIFF
--- a/rsatoolbox/rdm/rdms.py
+++ b/rsatoolbox/rdm/rdms.py
@@ -546,8 +546,8 @@ def permute_rdms(rdms, p=None):
     descriptors.update({'p_inv': p_inv})
     rdm_mats = rdm_mats[:, p, :]
     rdm_mats = rdm_mats[:, :, p]
-    stims = np.array(pattern_descriptors['stim'])
-    pattern_descriptors.update({'stim': list(stims[p].astype(np.str_))})
+    stims = np.array(pattern_descriptors['index'])
+    pattern_descriptors.update({'index': list(stims[p].astype(np.str_))})
 
     rdms_p = RDMs(
         dissimilarities=rdm_mats,


### PR DESCRIPTION
I think that at some point 'stim' changed to 'index' and this wasn't updated in this function (issue here #224) . Shown here is a working version of this function.

![image](https://user-images.githubusercontent.com/29523859/149423975-0df7adba-d801-4f8a-a563-482800ac6ac7.png)
