### PR TITLE
Dataset <--> pandas DataFrame

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -139,7 +139,8 @@ disable=print-statement,
         deprecated-sys-function,
         exception-escape,
         comprehension-escape,
-        no-self-use
+        no-self-use,
+        use-dict-literal
 
 # Enable the message, report, category or checker with the given id(s). You can
 # either give multiple identifier separated by comma (,) or put this option

--- a/.pylintrc
+++ b/.pylintrc
@@ -415,7 +415,9 @@ good-names=i,
            Run,
            by,
            t,
-           _
+           _,
+           df,
+           ds
 
 # Good variable names regexes, separated by a comma. If names match any regex,
 # they will always be accepted

--- a/docs/source/datasets.rst
+++ b/docs/source/datasets.rst
@@ -34,6 +34,13 @@ manipulating the data before RDM creation as well. It is thus convenient to add 
 To manipulate the datasets, have a look at the functions of the dataset object
 ``sort_by``, ``split_channel``, ``split_obs``, ``subset_channel``, ``subset_obs``.
 
+Datasets can also be created (and converted to) DataFrame objects from the pandas library:
+
+.. code-block:: python
+
+    df = data_in.to_DataFrame()
+    data_out = Dataset.from_DataFrame(df)
+
 The dataset objects can also be saved to hdf5 files using their method ``save`` as in and loaded with the ``rsatoolbox.data.load_dataset`` function:
 
 .. code-block:: python

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ h5py
 matplotlib
 joblib
 petname==2.2
+pandas

--- a/rsatoolbox/data/dataset.py
+++ b/rsatoolbox/data/dataset.py
@@ -209,7 +209,7 @@ class DatasetBase:
         """returns a Pandas DataFrame representing this Dataset
 
         Channels, observation descriptors and Dataset descriptors make up the 
-        channels. Rows represent observations.
+        columns. Rows represent observations.
 
         Note that channel descriptors beyond the one used for the column names
         will not be represented.
@@ -217,7 +217,11 @@ class DatasetBase:
         Returns:
             DataFrame: A pandas DataFrame representing the Dataset
         """
-        return DataFrame([])
+        ch_names = list(self.channel_descriptors.values())[0]
+        df = DataFrame(self.measurements, columns=ch_names)
+        for dname, dval in {**self.obs_descriptors, **self.descriptors}.items():
+            df[dname] = dval
+        return df
 
 
 class Dataset(DatasetBase):

--- a/rsatoolbox/data/dataset.py
+++ b/rsatoolbox/data/dataset.py
@@ -189,7 +189,7 @@ class DatasetBase:
         return data_dict
 
     @staticmethod
-    def from_DataFrame(
+    def from_df(
         df: DataFrame,
         channels: Optional[List]=None,
         channel_descriptor: Optional[str]=None) -> Dataset:
@@ -207,6 +207,7 @@ class DatasetBase:
                 By default all float columns are considered channels.
             channel_descriptor (str): Name of the channel descriptor to create
                 on the Dataset which contains the column names.
+                Default is "name".
 
         Returns:
             Dataset: RSAtoolbox Dataset representing the data from the DataFrame
@@ -229,7 +230,7 @@ class DatasetBase:
             channel_descriptors={channel_descriptor: channels}
         )
 
-    def to_DataFrame(self, channel_descriptor: Optional[str]=None) -> DataFrame:
+    def to_df(self, channel_descriptor: Optional[str]=None) -> DataFrame:
         """returns a Pandas DataFrame representing this Dataset
 
         Channels, observation descriptors and Dataset descriptors make up the

--- a/rsatoolbox/data/dataset.py
+++ b/rsatoolbox/data/dataset.py
@@ -6,8 +6,9 @@ Definition of RSA Dataset class and subclasses
 @author: baihan, jdiedrichsen, bpeters, adkipnis
 """
 
-
+from __future__ import annotations
 import numpy as np
+from pandas import DataFrame
 from rsatoolbox.util.data_utils import get_unique_unsorted
 from rsatoolbox.util.data_utils import get_unique_inverse
 from rsatoolbox.util.descriptor_utils import check_descriptor_length_error
@@ -185,6 +186,38 @@ class DatasetBase:
         data_dict['channel_descriptors'] = self.channel_descriptors
         data_dict['type'] = type(self).__name__
         return data_dict
+
+    @staticmethod
+    def from_DataFrame(df: DataFrame) -> Dataset:
+        """Create a Dataset from a Pandas DataFrame
+
+        Float columns are interpreted as channels, and their names stored as a
+        channel descriptor "name". 
+        Columns of any other datatype will be interpreted as observation 
+        descriptors, unless they have the same value throughout,
+        in which case they will be interpreted as Dataset descriptor.
+
+        Args:
+            df (DataFrame): DataFrame
+
+        Returns:
+            Dataset: RSAtoolbox Dataset representing the data from the DataFrame
+        """
+        return Dataset([])
+
+    def to_DataFrame(self) -> DataFrame:
+        """returns a Pandas DataFrame representing this Dataset
+
+        Channels, observation descriptors and Dataset descriptors make up the 
+        channels. Rows represent observations.
+
+        Note that channel descriptors beyond the one used for the column names
+        will not be represented.
+
+        Returns:
+            DataFrame: A pandas DataFrame representing the Dataset
+        """
+        return DataFrame([])
 
 
 class Dataset(DatasetBase):

--- a/rsatoolbox/data/dataset.py
+++ b/rsatoolbox/data/dataset.py
@@ -192,8 +192,8 @@ class DatasetBase:
         """Create a Dataset from a Pandas DataFrame
 
         Float columns are interpreted as channels, and their names stored as a
-        channel descriptor "name". 
-        Columns of any other datatype will be interpreted as observation 
+        channel descriptor "name".
+        Columns of any other datatype will be interpreted as observation
         descriptors, unless they have the same value throughout,
         in which case they will be interpreted as Dataset descriptor.
 
@@ -221,7 +221,7 @@ class DatasetBase:
     def to_DataFrame(self) -> DataFrame:
         """returns a Pandas DataFrame representing this Dataset
 
-        Channels, observation descriptors and Dataset descriptors make up the 
+        Channels, observation descriptors and Dataset descriptors make up the
         columns. Rows represent observations.
 
         Note that channel descriptors beyond the one used for the column names

--- a/rsatoolbox/data/dataset.py
+++ b/rsatoolbox/data/dataset.py
@@ -198,12 +198,25 @@ class DatasetBase:
         in which case they will be interpreted as Dataset descriptor.
 
         Args:
-            df (DataFrame): DataFrame
+            df (DataFrame): a long-format DataFrame
 
         Returns:
             Dataset: RSAtoolbox Dataset representing the data from the DataFrame
         """
-        return Dataset([])
+        channels = [c for (c, t) in df.dtypes.items() if 'float' in str(t)]
+        descriptors = set(df.columns).difference(channels)
+        ds_descriptors, obs_descriptors = dict(), dict()
+        for desc in descriptors:
+            if df[desc].unique().size == 1:
+                ds_descriptors[desc] = df[desc][0]
+            else:
+                obs_descriptors[desc] = list(df[desc])
+        return Dataset(
+            measurements=df[channels].values,
+            descriptors=ds_descriptors,
+            obs_descriptors=obs_descriptors,
+            channel_descriptors=dict(name=channels)
+        )
 
     def to_DataFrame(self) -> DataFrame:
         """returns a Pandas DataFrame representing this Dataset

--- a/tests/test_dataset_dataframe.py
+++ b/tests/test_dataset_dataframe.py
@@ -1,5 +1,5 @@
 from unittest import TestCase
-import numpy
+import numpy, pandas
 from numpy.testing import assert_array_equal
 
 
@@ -29,3 +29,45 @@ class DatasetToDataframeTests(TestCase):
         self.assertEqual(ds_out.descriptors, ds_in.descriptors)
         self.assertEqual(ds_out.obs_descriptors, ds_in.obs_descriptors)
         self.assertEqual(ds_out.channel_descriptors, ds_in.channel_descriptors)
+
+    def test_dataset_to_dataframe_spec_channel_desc(self):
+        """Converting a Dataset to a dataframe, and
+        we specify the descriptors to use.
+        """
+        from rsatoolbox.data.dataset import Dataset
+        ds_in = Dataset(
+            measurements=numpy.random.rand(3, 2),
+            descriptors=dict(foo='bar'),
+            obs_descriptors=dict(participant=['a', 'b', 'c']),
+            channel_descriptors=dict(foc=['x', 'y'], bac=[1, 2])
+        )
+        df = ds_in.to_DataFrame(channel_descriptor='bac')
+        assert_array_equal(df[1].values, ds_in.measurements[:, 0])
+        self.assertEqual(
+            df.columns.values.tolist(),
+            [1, 2, 'participant', 'foo']
+        )
+
+    def test_dataframe_to_dataset_spec_columns(self):
+        """Creating a Dataset from a dataframe, and
+        we specify the column roles.
+        """
+        from rsatoolbox.data.dataset import Dataset
+        df = pandas.DataFrame([
+            {'a': 1.1, 'b': 1, 3: 1.11, 'd': 'one', 'e': 1.111, 'f': 'bla'},
+            {'a': 2.2, 'b': 2, 3: 2.22, 'd': 'two', 'e': 2.222, 'f': 'bla'},
+            {'a': 3.3, 'b': 3, 3: 3.33, 'd': 'thr', 'e': 3.333, 'f': 'bla'},
+            {'a': 4.4, 'b': 4, 3: 4.44, 'd': 'fou', 'e': 4.444, 'f': 'bla'},
+        ])
+        ds = Dataset.from_DataFrame(
+            df,
+            channels=['a', 'b', 3],
+            channel_descriptor='foo'
+        )
+        assert_array_equal(ds.measurements, df[['a', 'b', 3]].values)
+        self.assertEqual(ds.descriptors, dict(f='bla'))
+        self.assertEqual(ds.obs_descriptors, dict(
+            d=['one', 'two', 'thr', 'fou'],
+            e=[1.111, 2.222, 3.333, 4.444]
+        ))
+        self.assertEqual(ds.channel_descriptors, dict(foo=['a', 'b', 3]))

--- a/tests/test_dataset_dataframe.py
+++ b/tests/test_dataset_dataframe.py
@@ -1,0 +1,29 @@
+from unittest import TestCase
+import numpy
+from numpy.testing import assert_array_equal
+
+
+class DatasetToDataframeTests(TestCase):
+    """Acceptance test for converting to a dataframe and back.
+    """
+
+    def test_dataset_to_dataframe_and_back(self):
+        """Converting a Dataset to a dataframe, and then loading that dataframe
+        as a DataSet should preserve data and some metadata.
+        """
+        from rsatoolbox.data.dataset import Dataset
+        ds_in = Dataset(
+            measurements=numpy.random.rand(3, 2),
+            descriptors=dict(foo='bar'),
+            obs_descriptors=dict(participant=['a', 'b', 'c']),
+            channel_descriptors=dict(name=['x', 'y'])
+        )
+        df = ds_in.to_DataFrame()
+        self.assertEqual(df.x.values, ds_in.measurements[:, 0])
+        self.assertEqual(df.columns, ['x', 'y', 'participant', 'foo'])
+        ds_out = Dataset.from_DataFrame(df)
+        assert_array_equal(ds_out.measurements, ds_in.measurements)
+        self.assertEqual(ds_out.measurements, ds_in.measurements)
+        self.assertEqual(ds_out.descriptors, ds_in.descriptors)
+        self.assertEqual(ds_out.obs_descriptors, ds_in.obs_descriptors)
+        self.assertEqual(ds_out.channel_descriptors, ds_in.channel_descriptors)

--- a/tests/test_dataset_dataframe.py
+++ b/tests/test_dataset_dataframe.py
@@ -1,5 +1,9 @@
+"""Various tests for converting Datasets to pandas.DataFrame and reverse
+"""
+# pylint: disable=C0415 ## allow imports on test level
 from unittest import TestCase
-import numpy, pandas
+import numpy
+import pandas
 from numpy.testing import assert_array_equal
 
 
@@ -18,13 +22,13 @@ class DatasetToDataframeTests(TestCase):
             obs_descriptors=dict(participant=['a', 'b', 'c']),
             channel_descriptors=dict(name=['x', 'y'])
         )
-        df = ds_in.to_DataFrame()
+        df = ds_in.to_df()
         assert_array_equal(df.x.values, ds_in.measurements[:, 0])
         self.assertEqual(
             df.columns.values.tolist(),
             ['x', 'y', 'participant', 'foo']
         )
-        ds_out = Dataset.from_DataFrame(df)
+        ds_out = Dataset.from_df(df)
         assert_array_equal(ds_out.measurements, ds_in.measurements)
         self.assertEqual(ds_out.descriptors, ds_in.descriptors)
         self.assertEqual(ds_out.obs_descriptors, ds_in.obs_descriptors)
@@ -41,7 +45,7 @@ class DatasetToDataframeTests(TestCase):
             obs_descriptors=dict(participant=['a', 'b', 'c']),
             channel_descriptors=dict(foc=['x', 'y'], bac=[1, 2])
         )
-        df = ds_in.to_DataFrame(channel_descriptor='bac')
+        df = ds_in.to_df(channel_descriptor='bac')
         assert_array_equal(df[1].values, ds_in.measurements[:, 0])
         self.assertEqual(
             df.columns.values.tolist(),
@@ -59,7 +63,7 @@ class DatasetToDataframeTests(TestCase):
             {'a': 3.3, 'b': 3, 3: 3.33, 'd': 'thr', 'e': 3.333, 'f': 'bla'},
             {'a': 4.4, 'b': 4, 3: 4.44, 'd': 'fou', 'e': 4.444, 'f': 'bla'},
         ])
-        ds = Dataset.from_DataFrame(
+        ds = Dataset.from_df(
             df,
             channels=['a', 'b', 3],
             channel_descriptor='foo'

--- a/tests/test_dataset_dataframe.py
+++ b/tests/test_dataset_dataframe.py
@@ -26,7 +26,6 @@ class DatasetToDataframeTests(TestCase):
         )
         ds_out = Dataset.from_DataFrame(df)
         assert_array_equal(ds_out.measurements, ds_in.measurements)
-        self.assertEqual(ds_out.measurements, ds_in.measurements)
         self.assertEqual(ds_out.descriptors, ds_in.descriptors)
         self.assertEqual(ds_out.obs_descriptors, ds_in.obs_descriptors)
         self.assertEqual(ds_out.channel_descriptors, ds_in.channel_descriptors)

--- a/tests/test_dataset_dataframe.py
+++ b/tests/test_dataset_dataframe.py
@@ -19,8 +19,11 @@ class DatasetToDataframeTests(TestCase):
             channel_descriptors=dict(name=['x', 'y'])
         )
         df = ds_in.to_DataFrame()
-        self.assertEqual(df.x.values, ds_in.measurements[:, 0])
-        self.assertEqual(df.columns, ['x', 'y', 'participant', 'foo'])
+        assert_array_equal(df.x.values, ds_in.measurements[:, 0])
+        self.assertEqual(
+            df.columns.values.tolist(),
+            ['x', 'y', 'participant', 'foo']
+        )
         ds_out = Dataset.from_DataFrame(df)
         assert_array_equal(ds_out.measurements, ds_in.measurements)
         self.assertEqual(ds_out.measurements, ds_in.measurements)


### PR DESCRIPTION
Proposal for DataFrame conversion of Datasets. This would make it a bit easier to write code for importing table-like data files, such as those stored in event files, CSVs.


### example
```python
ds_in = Dataset(
    measurements=numpy.random.rand(3, 2),
    descriptors=dict(foo='bar'),
    obs_descriptors=dict(abc=['a', 'b', 'c']),
    channel_descriptors=dict(name=['x', 'y'])
)
df = ds_in.to_DataFrame()
ds_out = Dataset.from_DataFrame(df)
print(df)
```
```
          x         y         abc  foo
0  0.709961  0.514268           a  bar
1  0.494080  0.100730           b  bar
2  0.922560  0.530450           c  bar
```

### Related 
- #160 
- #80 