### PR TITLE
Bugfix: RDM calculation sorting input data

### DIFF
--- a/rsatoolbox/rdm/calc.py
+++ b/rsatoolbox/rdm/calc.py
@@ -298,6 +298,7 @@ def calc_rdm_crossnobis(dataset, descriptor, noise=None,
     if descriptor is None:
         raise ValueError('descriptor must be a string! Crossvalidation' +
                          'requires multiple measurements to be grouped')
+    dataset = deepcopy(dataset)
     if cv_descriptor is None:
         cv_desc = _gen_default_cv_descriptor(dataset, descriptor)
         dataset.obs_descriptors['cv_desc'] = cv_desc
@@ -404,11 +405,11 @@ def calc_rdm_poisson_cv(dataset, descriptor=None, prior_lambda=1,
     if descriptor is None:
         raise ValueError('descriptor must be a string! Crossvalidation' +
                          'requires multiple measurements to be grouped')
+    dataset = deepcopy(dataset)
     if cv_descriptor is None:
         cv_desc = _gen_default_cv_descriptor(dataset, descriptor)
         dataset.obs_descriptors['cv_desc'] = cv_desc
         cv_descriptor = 'cv_desc'
-
     dataset.sort_by(descriptor)
     cv_folds = np.unique(np.array(dataset.obs_descriptors[cv_descriptor]))
     for i_fold in range(len(cv_folds)):


### PR DESCRIPTION
As noticed in #237 the cross validated distance computation sorted the input datasets as a side effect. This pull request removes this problem by copying before the sort.