### PR TITLE
deleted faulty indexing from batch_to_vectors

### DIFF
--- a/rsatoolbox/model/model.py
+++ b/rsatoolbox/model/model.py
@@ -112,6 +112,7 @@ class ModelFixed(Model):
         else:  # User passed a matrix
             self.rdm_obj = RDMs(np.array([rdm]))
             self.rdm, _, self.n_cond = batch_to_vectors(np.array([rdm]))
+            self.rdm = self.rdm[0]
         self.n_param = 0
         self.default_fitter = fit_mock
         self.rdm_obj.pattern_descriptors['index'] = np.arange(self.n_cond)

--- a/rsatoolbox/model/model.py
+++ b/rsatoolbox/model/model.py
@@ -111,7 +111,7 @@ class ModelFixed(Model):
             self.rdm = rdm
         else:  # User passed a matrix
             self.rdm_obj = RDMs(np.array([rdm]))
-            self.rdm, _, self.n_cond = batch_to_vectors(np.array([rdm]))[0]
+            self.rdm, _, self.n_cond = batch_to_vectors(np.array([rdm]))
         self.n_param = 0
         self.default_fitter = fit_mock
         self.rdm_obj.pattern_descriptors['index'] = np.arange(self.n_cond)

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -28,6 +28,13 @@ class TestModelFixed(unittest.TestCase):
         pred = m.predict()
         assert np.all(pred == rdm)
 
+    def test_creation_matrix(self):
+        rdm = np.array(np.ones(6, 6))
+        m = model.ModelFixed('Test Model', rdm)
+        m.fit([])
+        pred = m.predict()
+        assert np.all(pred == 1)
+
     def test_creation_rdm(self):
         from rsatoolbox.rdm import RDMs
         rdm = np.array(np.ones(6))

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -29,7 +29,7 @@ class TestModelFixed(unittest.TestCase):
         assert np.all(pred == rdm)
 
     def test_creation_matrix(self):
-        rdm = np.array(np.ones(6, 6))
+        rdm = np.array(np.ones((6, 6)))
         m = model.ModelFixed('Test Model', rdm)
         m.fit([])
         pred = m.predict()


### PR DESCRIPTION
There was a bug in ModelFixed that was caused by indexing the function to avoid multiple outputs but still unpacking the output. Should be fixed by deleting the indexing