### PR TITLE
Fix docstring typo in rdm_plot.py show_rdm

### DIFF
--- a/rsatoolbox/vis/rdm_plot.py
+++ b/rsatoolbox/vis/rdm_plot.py
@@ -54,7 +54,7 @@ def show_rdm(
             str for direct labeling.
         n_column (int): Number of columns in subplot arrangement.
         n_row (int): Number of rows in subplot arrangement.
-        show_colorbar (str): Set to 'panel' or 'colorbar' to display a colorbar. If
+        show_colorbar (str): Set to 'panel' or 'figure' to display a colorbar. If
             'panel' a colorbar is added next to each RDM. If 'figure' a shared colorbar
             (and scale) is used across panels.
         gridlines (npt.ArrayLike): Set to add gridlines at these positions. If


### PR DESCRIPTION
`show_colorbar` expects `'panel'` or `'figure'`: https://github.com/rsagroup/rsatoolbox/blob/de72c74/rsatoolbox/vis/rdm_plot.py#L94