### PR TITLE
Pair sampling by percentile

### DIFF
--- a/docs/source/rsatoolbox.rdm.pairs.rst
+++ b/docs/source/rsatoolbox.rdm.pairs.rst
@@ -1,0 +1,7 @@
+rsatoolbox.rdm.pairs module
+==========================
+
+.. automodule:: rsatoolbox.rdm.pairs
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/rsatoolbox.rdm.rst
+++ b/docs/source/rsatoolbox.rdm.rst
@@ -13,6 +13,7 @@ Submodules
    rsatoolbox.rdm.compare
    rsatoolbox.rdm.rdms
    rsatoolbox.rdm.transform
+   rsatoolbox.rdm.pairs
 
 Module contents
 ---------------

--- a/rsatoolbox/rdm/pairs.py
+++ b/rsatoolbox/rdm/pairs.py
@@ -10,8 +10,8 @@ if TYPE_CHECKING:
     from rsatoolbox.rdm.rdms import RDMs
 
 
-def pairs_by_percentile(rdms: RDMs, min: float=0, max: float=100,
-    **kwargs) -> DataFrame:
+def pairs_by_percentile(rdms: RDMs, min: float = 0, max: float = 100,
+        **kwargs) -> DataFrame:
     """Select pairs within a percentile range.
 
     Filter pairs first by providing the `with_pattern` argument.
@@ -31,7 +31,7 @@ def pairs_by_percentile(rdms: RDMs, min: float=0, max: float=100,
     row = mats[0, row_mask, :].squeeze()
     pair_dissims = row[~row_mask]
     percs = rankdata(pair_dissims, 'average') / pair_dissims.size * 100
-    matches = numpy.logical_and(percs>=min, percs<=max)
+    matches = numpy.logical_and(percs >= min, percs <= max)
     matches_mask = numpy.full_like(row, False, dtype=bool)
     matches_mask[~row_mask] = matches
     columns = dict()

--- a/rsatoolbox/rdm/pairs.py
+++ b/rsatoolbox/rdm/pairs.py
@@ -1,0 +1,26 @@
+"""Functions to select pairs
+"""
+from __future__ import annotations
+from typing import TYPE_CHECKING, Dict, Optional, Any
+from pandas import DataFrame
+if TYPE_CHECKING:
+    from rsatoolbox.rdm.rdms import RDMs
+
+
+def pairs_by_percentile(rdms: RDMs, min: float=0, max: float=100, 
+    with_pattern: Optional[Dict[str, Any]]=None) -> DataFrame:
+    """Select pairs within a percentile range.
+
+    Filter pairs first by providing the `with_pattern` argument.
+
+    Args:
+        rdms (RDMs): RDMs object
+        min (float, optional): Lower percentile bound. Defaults to 0.
+        max (float, optional): Upper percentile bound. Defaults to 100.
+        with_pattern (Optional[Dict], optional): Pattern Descriptor value to
+            match. Defaults to None.
+
+    Returns:
+        DataFrame: Wide form DataFrame where each row represents a pair.
+    """
+    return DataFrame()

--- a/rsatoolbox/rdm/pairs.py
+++ b/rsatoolbox/rdm/pairs.py
@@ -1,7 +1,8 @@
 """Functions to select pairs
 """
+# pylint: disable=redefined-builtin
 from __future__ import annotations
-from typing import TYPE_CHECKING, Dict, Optional, Any
+from typing import TYPE_CHECKING
 from pandas import DataFrame
 import numpy
 from scipy.stats import rankdata
@@ -9,7 +10,7 @@ if TYPE_CHECKING:
     from rsatoolbox.rdm.rdms import RDMs
 
 
-def pairs_by_percentile(rdms: RDMs, min: float=0, max: float=100, 
+def pairs_by_percentile(rdms: RDMs, min: float=0, max: float=100,
     **kwargs) -> DataFrame:
     """Select pairs within a percentile range.
 

--- a/rsatoolbox/rdm/pairs.py
+++ b/rsatoolbox/rdm/pairs.py
@@ -30,7 +30,6 @@ def pairs_by_percentile(rdms: RDMs, min: float=0, max: float=100,
     row = mats[0, row_mask, :].squeeze()
     pair_dissims = row[~row_mask]
     percs = rankdata(pair_dissims, 'average') / pair_dissims.size * 100
-    print(percs)
     matches = numpy.logical_and(percs>=min, percs<=max)
     matches_mask = numpy.full_like(row, False, dtype=bool)
     matches_mask[~row_mask] = matches

--- a/tests/test_pair_selection.py
+++ b/tests/test_pair_selection.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+from unittest import TestCase
+from pandas.util.testing import assert_frame_equal
+import numpy
+import pandas
+
+
+class PairSelectionTests(TestCase):
+
+    def test_percentile_with_target(self):
+        """From pairs which include the target pattern,
+        return those that fall under the given percentile.
+        """
+        from rsatoolbox.rdm.rdms import RDMs
+        from rsatoolbox.rdm.pairs import select_pairs_by_percentile
+        rdms = RDMs()
+        select_pairs_by_percentile(group_rdm, -67, with_pattern=dict())
+        assert_frame_equal()

--- a/tests/test_pair_selection.py
+++ b/tests/test_pair_selection.py
@@ -22,16 +22,16 @@ class PairSelectionTests(TestCase):
                 [4, 5, 9, 0, 9],
                 [3, 4, 9, 9, 0],
             ])),
-            pattern_descriptors=dict(cond=['a', 'b', 'c', 'd', 'e'])
+            pattern_descriptors=dict(cond=array(['a', 'b', 'c', 'd', 'e']))
         )
         ## 25% lowest dissimilarities
-        out = pairs_by_percentile(rdms, max=25, with_pattern=dict(cond='a'))
+        out = pairs_by_percentile(rdms, max=25, cond='a')
         assert_frame_equal(out, DataFrame([
-            dict(cond='e', dissim=3),
+            dict(cond='e', dissim=3.0),
         ]))
         ## 40% - 80% mid range dissimilarities
-        out = pairs_by_percentile(rdms, min=40, max=70, with_pattern=dict(cond='b'))
+        out = pairs_by_percentile(rdms, min=40, max=80, cond='b')
         assert_frame_equal(out, DataFrame([
-            dict(cond='c', dissim=6),
-            dict(cond='d', dissim=5),
+            dict(cond='c', dissim=6.0),
+            dict(cond='d', dissim=5.0),
         ]))

--- a/tests/test_pair_selection.py
+++ b/tests/test_pair_selection.py
@@ -1,18 +1,37 @@
 from __future__ import annotations
 from unittest import TestCase
-from pandas.util.testing import assert_frame_equal
-import numpy
-import pandas
+from pandas.testing import assert_frame_equal
+from pandas import DataFrame
+from numpy import array
+from scipy.spatial.distance import squareform
 
 
 class PairSelectionTests(TestCase):
 
     def test_percentile_with_target(self):
         """From pairs which include the target pattern,
-        return those that fall under the given percentile.
+        return those that fall between the given percentiles.
         """
         from rsatoolbox.rdm.rdms import RDMs
-        from rsatoolbox.rdm.pairs import select_pairs_by_percentile
-        rdms = RDMs()
-        select_pairs_by_percentile(group_rdm, -67, with_pattern=dict())
-        assert_frame_equal()
+        from rsatoolbox.rdm.pairs import pairs_by_percentile
+        rdms = RDMs(
+            dissimilarities=squareform(array([
+                [0, 7, 5, 4, 3],
+                [7, 0, 6, 5, 4],
+                [5, 6, 0, 9, 9],
+                [4, 5, 9, 0, 9],
+                [3, 4, 9, 9, 0],
+            ])),
+            pattern_descriptors=dict(cond=['a', 'b', 'c', 'd', 'e'])
+        )
+        ## 25% lowest dissimilarities
+        out = pairs_by_percentile(rdms, max=25, with_pattern=dict(cond='a'))
+        assert_frame_equal(out, DataFrame([
+            dict(cond='e', dissim=3),
+        ]))
+        ## 40% - 80% mid range dissimilarities
+        out = pairs_by_percentile(rdms, min=40, max=70, with_pattern=dict(cond='b'))
+        assert_frame_equal(out, DataFrame([
+            dict(cond='c', dissim=6),
+            dict(cond='d', dissim=5),
+        ]))


### PR DESCRIPTION
When selecting a subset of stimuli for a behavioural experiment, it is common to sample them according to bins of the similarity distribution; for instance, *find 3 stimuli that are among the top 10% most similar to stimulus A*.

The function in this PR aims to provide this as a simple function. Open to suggestions on naming or whether this should be a method instead?