### PR TITLE
small bug fix for list descriptors in RDM calculations

### DIFF
--- a/src/rsatoolbox/rdm/calc.py
+++ b/src/rsatoolbox/rdm/calc.py
@@ -509,7 +509,7 @@ def _build_rdms(
         _, obs_desc_vals, _ = average_dataset_by(ds, obs_desc_name)
 
     if _averaging_occurred(ds, obs_desc_name, obs_desc_vals):
-        orig_obs_desc_vals = ds.obs_descriptors[obs_desc_name]
+        orig_obs_desc_vals = np.asarray(ds.obs_descriptors[obs_desc_name])
         for dname, dvals in ds.obs_descriptors.items():
             dvals = np.asarray(dvals)
             avg_dvals = np.full_like(obs_desc_vals, np.nan, dtype=dvals.dtype)

--- a/tests/test_calc_rdm.py
+++ b/tests/test_calc_rdm.py
@@ -315,7 +315,9 @@ class TestCalcRDM(unittest.TestCase):
         """Can the calc methods deal with descriptors
         that are defined as List.
         """
-        conds_list = self.test_data.obs_descriptors['conds'].tolist()
+        conds_list = [
+            str(i)
+            for i in self.test_data.obs_descriptors['conds']
         self.test_data.obs_descriptors['conds'] = conds_list
         rdms = rsr.calc_rdm(
             self.test_data,

--- a/tests/test_calc_rdm.py
+++ b/tests/test_calc_rdm.py
@@ -311,6 +311,22 @@ class TestCalcRDM(unittest.TestCase):
             self.test_data.obs_descriptors['conds']
         )
 
+    def test_calc_with_descriptors_as_list(self):
+        """Can the calc methods deal with descriptors
+        that are defined as List.
+        """
+        conds_list = self.test_data.obs_descriptors['conds'].tolist()
+        self.test_data.obs_descriptors['conds'] = conds_list
+        rdms = rsr.calc_rdm(
+            self.test_data,
+            descriptor='conds',
+            method='euclidean'
+        )
+        assert_array_equal(
+            rdms.pattern_descriptors['conds'],
+            np.unique(self.test_data.obs_descriptors['conds'])
+        )
+
 
 class TestCalcRDMMovie(unittest.TestCase):
 

--- a/tests/test_calc_rdm.py
+++ b/tests/test_calc_rdm.py
@@ -317,7 +317,7 @@ class TestCalcRDM(unittest.TestCase):
         """
         conds_list = [
             str(i)
-            for i in self.test_data.obs_descriptors['conds']
+            for i in self.test_data.obs_descriptors['conds']]
         self.test_data.obs_descriptors['conds'] = conds_list
         rdms = rsr.calc_rdm(
             self.test_data,


### PR DESCRIPTION
List descriptors in the original dataset were breaking _build_rdms
This can be fixed with a simple np.asarray as I implement here.