### PR TITLE
Integer input for unbalanced calc functions

### DIFF
--- a/src/rsatoolbox/rdm/calc_unbalanced.py
+++ b/src/rsatoolbox/rdm/calc_unbalanced.py
@@ -116,7 +116,8 @@ def calc_rdm_unbalanced(dataset: SingleOrMultiDataset, method='euclidean',
             weight_idx = 1
         cond_indices_int = cond_indices.astype(int)
         rdm = calc(
-            dataset.measurements, cond_indices_int,
+            ensure_double(dataset.measurements),
+            cond_indices_int,
             cv_desc_int, len(unique_cond),
             method_idx, noise,
             prior_lambda, prior_weight,
@@ -170,14 +171,33 @@ def calc_one_similarity(data_i: DatasetBase, data_j: DatasetBase,
         method_idx = 3
     elif method in ['poisson', 'poisson_cv']:
         method_idx = 4
+    else:
+        raise ValueError(f'Unknown method: {method}')
     if weighting == 'equal':
         weight_idx = 0
     else:
         weight_idx = 1
     return calc_one(
-        data_i.measurements, data_j.measurements,
+        ensure_double(data_i.measurements),
+        ensure_double(data_j.measurements),
         cv_desc_i, cv_desc_j,
         data_i.n_obs, data_j.n_obs,
         method_idx, noise=noise,
         prior_lambda=prior_lambda, prior_weight=prior_weight,
         weighting=weight_idx)
+
+
+def ensure_double(a: NDArray) -> NDArray[np.float64]:
+    """If required, will convert the array datatype to Float64
+
+    This ensures compatibility with the underlying c type "double".
+    If the array is already compatible, it will pass through.
+    If it is an integer, a converted copy will be made.
+
+    Args:
+        a (NDArray): Numeric numpy array
+
+    Returns:
+        NDArray[np.float64]: The float64 version of the array
+    """
+    return a.astype(np.float64)

--- a/tests/test_c.py
+++ b/tests/test_c.py
@@ -5,6 +5,7 @@
 
 import unittest
 import numpy as np
+from numpy.testing import assert_almost_equal
 import rsatoolbox
 from rsatoolbox.cengine.similarity import similarity as similarity_c
 from rsatoolbox.cengine.similarity import calc
@@ -125,6 +126,17 @@ class TestCalc(unittest.TestCase):
                 np.testing.assert_allclose(
                     np.expand_dims(rdm, 0), c.dissimilarities,
                     err_msg='unbalanced unequal to balanced for %s' % method)
+
+    def test_integer_input(self):
+        from rsatoolbox.data.dataset import Dataset
+        from rsatoolbox.rdm.calc_unbalanced import calc_rdm_unbalanced
+        ds = Dataset(np.asarray([[0, 2], [0, 2]]))
+        rdms = calc_rdm_unbalanced(ds)
+        assert_almost_equal(
+            rdms.dissimilarities,
+            [1.41, 2.83, 1.41],
+            decimal=2
+        )
 
 
 # Original Python version used as reference implementation:

--- a/tests/test_c.py
+++ b/tests/test_c.py
@@ -64,7 +64,6 @@ class TestCalcOne(unittest.TestCase):
         self.dat_i = np.random.rand(2, 21)
         self.dat_j = np.random.rand(3, 21)
         self.dat = np.concatenate((self.dat_i, self.dat_j), 0)
-        print(self.dat)
         self.data = rsatoolbox.data.Dataset(
             self.dat, obs_descriptors={'idx': [1, 1, 2, 2, 2]})
 
@@ -90,14 +89,10 @@ class TestCalcOne(unittest.TestCase):
     def test_integer_input_one(self):
         from rsatoolbox.data.dataset import Dataset
         from rsatoolbox.rdm.calc_unbalanced import calc_one_similarity
-        ds1 = Dataset(np.asarray([[0, 2], [0, 2]]))
-        ds2 = Dataset(np.asarray([[1, 3], [1, 3]]))
-        rdms = calc_one_similarity(ds1, ds2, np.arange(0, 2), np.arange(2, 4))
-        assert_almost_equal(
-            rdms.dissimilarities,
-            [1.41, 2.83, 1.41],
-            decimal=2
-        )
+        ds1 = Dataset(np.asarray([[0], [2]]).T)  # one pattern, two channels
+        ds2 = Dataset(np.asarray([[0], [2]]).T)  # one pattern, two channels
+        dissim, _ = calc_one_similarity(ds1, ds2, np.array([0]), np.array([1]))
+        assert_almost_equal(dissim, 4)  # standard-squared euclidean
 
 
 class TestCalc(unittest.TestCase):
@@ -142,13 +137,9 @@ class TestCalc(unittest.TestCase):
     def test_integer_input_rdm(self):
         from rsatoolbox.data.dataset import Dataset
         from rsatoolbox.rdm.calc_unbalanced import calc_rdm_unbalanced
-        ds = Dataset(np.asarray([[0, 2], [0, 2]]))
+        ds = Dataset(np.asarray([[0, 0], [2, 2]]))
         rdms = calc_rdm_unbalanced(ds)
-        assert_almost_equal(
-            rdms.dissimilarities,
-            [1.41, 2.83, 1.41],
-            decimal=2
-        )
+        assert_almost_equal(rdms.dissimilarities, 4)
 
 
 # Original Python version used as reference implementation:

--- a/tests/test_c.py
+++ b/tests/test_c.py
@@ -91,7 +91,7 @@ class TestCalcOne(unittest.TestCase):
         ds1 = Dataset(np.asarray([[0], [2]]).T)  # one pattern, two channels
         ds2 = Dataset(np.asarray([[0], [2]]).T)  # one pattern, two channels
         dissim, _ = calc_one_similarity_c(ds1, ds2, np.array([0]), np.array([1]))
-        assert_almost_equal(dissim, 4)  # standard-squared euclidean
+        assert_almost_equal(dissim, 2)  # standard-squared euclidean
 
 
 class TestCalc(unittest.TestCase):

--- a/tests/test_c.py
+++ b/tests/test_c.py
@@ -88,10 +88,9 @@ class TestCalcOne(unittest.TestCase):
 
     def test_integer_input_one(self):
         from rsatoolbox.data.dataset import Dataset
-        from rsatoolbox.rdm.calc_unbalanced import calc_one_similarity
         ds1 = Dataset(np.asarray([[0], [2]]).T)  # one pattern, two channels
         ds2 = Dataset(np.asarray([[0], [2]]).T)  # one pattern, two channels
-        dissim, _ = calc_one_similarity(ds1, ds2, np.array([0]), np.array([1]))
+        dissim, _ = calc_one_similarity_c(ds1, ds2, np.array([0]), np.array([1]))
         assert_almost_equal(dissim, 4)  # standard-squared euclidean
 
 

--- a/tests/test_c.py
+++ b/tests/test_c.py
@@ -87,6 +87,18 @@ class TestCalcOne(unittest.TestCase):
                 sim, sim_c, None,
                 'C unequal to python for %s' % method)
 
+    def test_integer_input_one(self):
+        from rsatoolbox.data.dataset import Dataset
+        from rsatoolbox.rdm.calc_unbalanced import calc_one_similarity
+        ds1 = Dataset(np.asarray([[0, 2], [0, 2]]))
+        ds2 = Dataset(np.asarray([[1, 3], [1, 3]]))
+        rdms = calc_one_similarity(ds1, ds2, np.arange(0, 2), np.arange(2, 4))
+        assert_almost_equal(
+            rdms.dissimilarities,
+            [1.41, 2.83, 1.41],
+            decimal=2
+        )
+
 
 class TestCalc(unittest.TestCase):
 
@@ -127,7 +139,7 @@ class TestCalc(unittest.TestCase):
                     np.expand_dims(rdm, 0), c.dissimilarities,
                     err_msg='unbalanced unequal to balanced for %s' % method)
 
-    def test_integer_input(self):
+    def test_integer_input_rdm(self):
         from rsatoolbox.data.dataset import Dataset
         from rsatoolbox.rdm.calc_unbalanced import calc_rdm_unbalanced
         ds = Dataset(np.asarray([[0, 2], [0, 2]]))


### PR DESCRIPTION
It seems the the Cython code expects floats, and the python wrappers do not reject or handle integers.