### PR TITLE
Visualization support for `rho-a`

### DIFF
--- a/src/rsatoolbox/vis/model_plot.py
+++ b/src/rsatoolbox/vis/model_plot.py
@@ -987,4 +987,7 @@ def _get_y_label(method):
     elif method.lower() == 'neg_riem_dist':
         y_label = '[across-subject mean of ' \
             + 'negative riemannian distance]'
+    elif method.lower() == 'rho-a':
+        y_label = '[across-subject mean of ' \
+            + 'Spearman r rank correlation with random tie-breaking]'
     return y_label

--- a/tests/test_vis.py
+++ b/tests/test_vis.py
@@ -163,11 +163,17 @@ class Test_rdm_plot(TestCase):
 
 
 class Test_model_plot(TestCase):
+    methods_supported = [
+        "corr", "cosine", "cosine_cov", "spearman", "corr_cov",
+        "tau-b", "tau-a", "neg_riem_dist", "rho-a"
+    ]
     def test_y_label(self):
         from rsatoolbox.vis.model_plot import _get_y_label
 
-        y_label = _get_y_label("corr")
-        self.assertIsInstance(y_label, str)
+        for this_method in self.methods_supported:
+            with self.subTest(msg=f"Testing {this_method}..."):
+                y_label = _get_y_label(this_method)
+                self.assertIsInstance(y_label, str)
 
     def test_descr(self):
         from rsatoolbox.vis.model_plot import _get_model_comp_descr


### PR DESCRIPTION
Fixes #311 , added unit tests for all supported rdm visualization methods for `test_y_labels` in `test_vis.py`.

First time contributing, please let me know what are the guidelines (if any) I'm missing.