### PR TITLE
allow python 3.11

### DIFF
--- a/.github/workflows/testbuild.yml
+++ b/.github/workflows/testbuild.yml
@@ -18,7 +18,7 @@ jobs:
         fetch-depth: 0
     - uses: actions/setup-python@v4
       with:
-        python-version: '3.10'
+        python-version: '3.11'
     - name: Python Version
       run: python --version
     - name: Update Pip
@@ -39,7 +39,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: ['3.7', '3.8', '3.9', '3.10']
+        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
         os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
     - uses: actions/checkout@v3
@@ -94,7 +94,7 @@ jobs:
         fetch-depth: 0
     - uses: actions/setup-python@v4
       with:
-        python-version: '3.10'
+        python-version: '3.11'
     - name: Python Version
       run: python --version
     - name: Update Pip

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "rsatoolbox"
 description = "Representational Similarity Analysis (RSA) in Python"
-requires-python = ">=3.7,<3.11"
+requires-python = ">=3.7,<3.12"
 authors = [
     {name="rsatoolbox authors"},
 ]
@@ -30,6 +30,7 @@ classifiers = [
       'Programming Language :: Python :: 3.8',
       'Programming Language :: Python :: 3.9',
       'Programming Language :: Python :: 3.10',
+      'Programming Language :: Python :: 3.11',
 ]
 dynamic = ["readme", "dependencies", "version"]
 


### PR DESCRIPTION
When setting up my new computer I noticed that python 3.11 is now the default installed version, which rsatoolbox currently does not allow. Here I'll setup things to make it accept and test python 3.11