### PR TITLE
ReadTheDocs: new build image

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -12,6 +12,8 @@ formats: all
 
 build:
   os: ubuntu-22.04
+  tools:
+    python: "3.8"
 
 # Optionally set the version of Python and requirements required to build your docs
 python:

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -10,9 +10,12 @@ sphinx:
 # Optionally build your docs in additional formats such as PDF
 formats: all
 
+build:
+  os: ubuntu-22.04
+
 # Optionally set the version of Python and requirements required to build your docs
 python:
-  version: 3.7
+  version: 3.8
   install:
     - requirements: requirements.txt
     - requirements: docs/requirements.txt

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -17,7 +17,6 @@ build:
 
 # Optionally set the version of Python and requirements required to build your docs
 python:
-  version: 3.8
   install:
     - requirements: requirements.txt
     - requirements: docs/requirements.txt


### PR DESCRIPTION
Our documentation builds are currently failing since we are defaulting to an older container image, which, after a new release of `urllib3`, is causing a dependency conflict with `requests`.

relates to https://github.com/psf/requests/issues/6432