### PR TITLE
data split bug

### DIFF
--- a/.github/workflows/testbuild.yml
+++ b/.github/workflows/testbuild.yml
@@ -31,8 +31,8 @@ jobs:
       run: pip install -r tests/requirements.txt
     - name: Skeleton tests
       run: python -m unittest -v rsatoolbox.test
-    - name: Setup tmate session
-      uses: mxschmitt/action-tmate@v3
+    # - name: Setup tmate session
+    #   uses: mxschmitt/action-tmate@v3
     - name: Unit tests
       run: pytest
 

--- a/.github/workflows/testbuild.yml
+++ b/.github/workflows/testbuild.yml
@@ -18,7 +18,7 @@ jobs:
         fetch-depth: 0
     - uses: actions/setup-python@v4
       with:
-        python-version: '3.11'
+        python-version: '3.10'
     - name: Python Version
       run: python --version
     - name: Update Pip

--- a/.github/workflows/testbuild.yml
+++ b/.github/workflows/testbuild.yml
@@ -18,7 +18,7 @@ jobs:
         fetch-depth: 0
     - uses: actions/setup-python@v4
       with:
-        python-version: '3.10'
+        python-version: '3.11'
     - name: Python Version
       run: python --version
     - name: Update Pip

--- a/.github/workflows/testbuild.yml
+++ b/.github/workflows/testbuild.yml
@@ -31,8 +31,6 @@ jobs:
       run: pip install -r tests/requirements.txt
     - name: Skeleton tests
       run: python -m unittest -v rsatoolbox.test
-    # - name: Setup tmate session
-    #   uses: mxschmitt/action-tmate@v3
     - name: Unit tests
       run: pytest
 

--- a/.github/workflows/testbuild.yml
+++ b/.github/workflows/testbuild.yml
@@ -31,6 +31,8 @@ jobs:
       run: pip install -r tests/requirements.txt
     - name: Skeleton tests
       run: python -m unittest -v rsatoolbox.test
+    - name: Setup tmate session
+      uses: mxschmitt/action-tmate@v3
     - name: Unit tests
       run: pytest
 

--- a/src/rsatoolbox/data/dataset.py
+++ b/src/rsatoolbox/data/dataset.py
@@ -180,7 +180,7 @@ class Dataset(DatasetBase):
 
         """
         desc = self.obs_descriptors[by]
-        order = np.argsort(desc)
+        order = np.argsort(desc, kind='stable')
         self.measurements = self.measurements[order]
         self.obs_descriptors = subset_descriptor(self.obs_descriptors, order)
 

--- a/src/rsatoolbox/data/dataset.py
+++ b/src/rsatoolbox/data/dataset.py
@@ -685,21 +685,6 @@ class TemporalDataset(Dataset):
             time_descriptors=time_descriptors)
         return dataset
 
-    def sort_by(self, by):
-        """ sorts the dataset by a given observation descriptor
-
-        Args:
-            by(String): the descriptor by which the dataset shall be sorted
-
-        Returns:
-            ---
-
-        """
-        desc = self.obs_descriptors[by]
-        order = np.argsort(desc)
-        self.measurements = self.measurements[order]
-        self.obs_descriptors = subset_descriptor(self.obs_descriptors, order)
-
     def convert_to_dataset(self, by):
         """ converts to Dataset long format.
             time dimension is absorbed into observation dimension


### PR DESCRIPTION
data split test `test_odd_even_split_nested` fails on server (python 3.11.4 linux) but not locally (python 3.11.2 osx)

In addition I've removed a duplicate `sort_by` from `TemporalDataset`

## Cause

Numpy sorting implementations are chosen wrt to the underlying datatype (for optimization). However this means a non-stable algorithm may be chosen. The underlying datatype may vary with platform, which is why we were not able to replicate this locally. When we expect stable sorting from numpy, we should from now specify this (even if locally it may sort in a stable fashion regardless).
In general I think we should even be cautious when applying numpy functions to non-numerical data.

See "notes" section here: https://numpy.org/doc/stable/reference/generated/numpy.sort.html#numpy.sort