### PR TITLE
Error 0 div

### DIFF
--- a/src/rsatoolbox/inference/evaluate.py
+++ b/src/rsatoolbox/inference/evaluate.py
@@ -525,7 +525,10 @@ def bootstrap_crossval(models, data, method='cosine', fitter=None,
     if k_rdm is None:
         n_rdm = len(np.unique(data.rdm_descriptors[
             rdm_descriptor]))
-        k_rdm = default_k_rdm((1 - 1 / np.exp(1)) * n_rdm)
+        if n_rdm == 1:
+            k_rdm = 1
+        else:
+            k_rdm = default_k_rdm((1 - 1 / np.exp(1)) * n_rdm)
     if isinstance(models, Model):
         models = [models]
     evaluations = np.empty((N, len(models), k_pattern * k_rdm, n_cv))
@@ -565,12 +568,18 @@ def bootstrap_crossval(models, data, method='cosine', fitter=None,
     if boot_type == 'both':
         cv_method = 'bootstrap_crossval'
         dof = min(data.n_rdm, data.n_cond) - 1
+        n_rdm = data.n_rdm
+        n_cond = data.n_cond
     elif boot_type == 'pattern':
         cv_method = 'bootstrap_crossval_pattern'
         dof = data.n_cond - 1
+        n_rdm = None
+        n_cond = data.n_cond
     elif boot_type == 'rdm':
         cv_method = 'bootstrap_crossval_rdm'
         dof = data.n_rdm - 1
+        n_rdm = data.n_rdm
+        n_cond = None
     eval_ok = ~np.isnan(evaluations[:, 0, 0, 0])
     if use_correction and n_cv > 1:
         # we essentially project from the two points for 1 repetition and
@@ -598,8 +607,8 @@ def bootstrap_crossval(models, data, method='cosine', fitter=None,
         variances = np.cov(np.concatenate([evals_nonan.T, noise_ceil_nonan]))
     result = Result(models, evaluations, method=method,
                     cv_method=cv_method, noise_ceiling=noise_ceil,
-                    variances=variances, dof=dof, n_rdm=data.n_rdm,
-                    n_pattern=data.n_cond)
+                    variances=variances, dof=dof, n_rdm=n_rdm,
+                    n_pattern=n_cond)
     return result
 
 

--- a/src/rsatoolbox/inference/result.py
+++ b/src/rsatoolbox/inference/result.py
@@ -173,6 +173,8 @@ class Result:
         result_dict['noise_ceiling'] = self.noise_ceiling
         result_dict['method'] = self.method
         result_dict['cv_method'] = self.cv_method
+        result_dict['n_rdm'] = self.n_rdm
+        result_dict['n_pattern'] = self.n_pattern
         result_dict['models'] = {}
         for i_model in range(len(self.models)):
             key = 'model_%d' % i_model
@@ -329,5 +331,7 @@ def result_from_dict(result_dict):
         key = 'model_%d' % i_model
         models[i_model] = rsatoolbox.model.model_from_dict(
             result_dict['models'][key])
+    n_rdm = result_dict['n_rdm']
+    n_pattern = result_dict['n_pattern']
     return Result(models, evaluations, method, cv_method, noise_ceiling,
-                  variances=variances, dof=dof)
+                  variances=variances, dof=dof, n_rdm=n_rdm, n_pattern=n_pattern)

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -423,3 +423,13 @@ class TestsExtractVar(unittest.TestCase):
         self.assertEqual(diff_variances.shape[0], 45)
         self.assertEqual(nc_variances.shape[0], 10)
         self.assertEqual(nc_variances.shape[1], 2)
+
+    def test_zero_div(self):
+        """This integration test makes sure things work when only 1 RDM is passed"""
+        from rsatoolbox.rdm import RDMs
+        from rsatoolbox.model import ModelFixed
+        from rsatoolbox.inference import bootstrap_crossval
+        model = ModelFixed('m', np.random.rand(10))
+        data = RDMs(np.random.rand(10))
+        result = bootstrap_crossval(model, data, boot_type="pattern")
+        assert np.isfinite(result.model_var[0])

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -429,7 +429,7 @@ class TestsExtractVar(unittest.TestCase):
         from rsatoolbox.rdm import RDMs
         from rsatoolbox.model import ModelFixed
         from rsatoolbox.inference import bootstrap_crossval
-        model = ModelFixed('m', np.random.rand(10))
-        data = RDMs(np.random.rand(10))
-        result = bootstrap_crossval(model, data, boot_type="pattern")
+        model = ModelFixed('m', np.random.rand(190))
+        data = RDMs(np.random.rand(190))
+        result = bootstrap_crossval(model, data, boot_type="pattern", N=100)
         assert np.isfinite(result.model_var[0])


### PR DESCRIPTION
Bugfix for #357 

bootstrap_crossval passed the wrong n combinations to the Results construction if run with only one bootstrap factor.

Also this now defaults to no crossvalidation if only one RDM is passed as data.