### PR TITLE
`RDMs.sort_by(reindex)` argument

### DIFF
--- a/src/rsatoolbox/rdm/rdms.py
+++ b/src/rsatoolbox/rdm/rdms.py
@@ -422,8 +422,12 @@ class RDMs:
         for dname, descriptors in self.pattern_descriptors.items():
             self.pattern_descriptors[dname] = [descriptors[idx] for idx in new_order]
 
-    def sort_by(self, **kwargs):
+    def sort_by(self, reindex: bool = True, **kwargs):
         """Reorder the patterns by sorting a descriptor
+
+        Args:
+            reindex (bool): whether to reset the 'index' descriptor 
+                following sorting
 
         Pass keyword arguments that correspond to descriptors,
         with value indicating the sort type. Supported methods:
@@ -466,6 +470,8 @@ class RDMs:
                 self.reorder([list(descriptor).index(x) for x in new_order])
             else:
                 raise ValueError(f'Unknown sorting method: {method}')
+        if reindex:
+            self.pattern_descriptors[INDEX] = list(range(self.n_cond))
 
     def mean(self, weights=None):
         """Average rdm of all rdms contained

--- a/src/rsatoolbox/rdm/rdms.py
+++ b/src/rsatoolbox/rdm/rdms.py
@@ -471,7 +471,7 @@ class RDMs:
             else:
                 raise ValueError(f'Unknown sorting method: {method}')
         if reindex:
-            self.pattern_descriptors[INDEX] = list(range(self.n_cond))
+            self.pattern_descriptors['index'] = list(range(self.n_cond))
 
     def mean(self, weights=None):
         """Average rdm of all rdms contained

--- a/tests/test_rdm.py
+++ b/tests/test_rdm.py
@@ -429,6 +429,44 @@ class TestRDM(unittest.TestCase):
             )
         )
 
+    def test_sort_by_reindex_resets_index(self):
+        from rsatoolbox.rdm import RDMs
+        rdm = np.array([
+            [0., 1., 2., 3.],
+            [1., 0., 1., 2.],
+            [2., 1., 0., 1.],
+            [3., 2., 1., 0.]]
+        )
+        conds = ['b', 'a', 'c', 'd']
+        rdms = RDMs(
+            np.atleast_2d(squareform(rdm)),
+            pattern_descriptors=dict(conds=conds)
+        )
+        rdms.sort_by(conds='alpha', reindex=True)
+        self.assertEqual(
+            rdms.pattern_descriptors['index'],
+            list(range(rdms.n_cond))
+        )
+
+    def test_sort_by_not_reindex_does_not_reset_index(self):
+        from rsatoolbox.rdm import RDMs
+        rdm = np.array([
+            [0., 1., 2., 3.],
+            [1., 0., 1., 2.],
+            [2., 1., 0., 1.],
+            [3., 2., 1., 0.]]
+        )
+        conds = ['b', 'a', 'c', 'd']
+        rdms = RDMs(
+            np.atleast_2d(squareform(rdm)),
+            pattern_descriptors=dict(conds=conds)
+        )
+        rdms.sort_by(conds='alpha', reindex=False)
+        self.assertNotEqual(
+            rdms.pattern_descriptors['index'],
+            list(range(rdms.n_cond))
+        )
+
     def test_sort_by_list(self):
         from rsatoolbox.rdm import RDMs
         rdm = np.array([


### PR DESCRIPTION
Adds a new `reindex: bool` argument to `RDMs.sort_by()`, default `True`, which resets the index after sorting.

@JasperVanDenBosch [suggested](https://github.com/rsagroup/rsatoolbox/issues/358#issuecomment-1801824285) that it also throw a depricationwarning, but I'm not sure what the policy is on this.

Fixes #358.

## Some issues

If the RDMs has a `pattern_descriptor` named "reindex", this will upset the function. I'm not sure what to do about this, other than change the signature of `sort_by()`.