### PR TITLE
RDMs.sort_by is stable

### DIFF
--- a/src/rsatoolbox/rdm/rdms.py
+++ b/src/rsatoolbox/rdm/rdms.py
@@ -454,7 +454,7 @@ class RDMs:
         for dname, method in kwargs.items():
             if method == 'alpha':
                 descriptor = self.pattern_descriptors[dname]
-                self.reorder(np.argsort(descriptor))
+                self.reorder(np.argsort(descriptor, kind='stable'))
             elif isinstance(method, (list, np.ndarray)):
                 # in this case, `method` is the desired descriptor order
                 new_order = method

--- a/tests/test_rdm.py
+++ b/tests/test_rdm.py
@@ -460,6 +460,35 @@ class TestRDM(unittest.TestCase):
             )
         )
 
+    def test_sort_stable(self):
+        from rsatoolbox.rdm import RDMs
+        rdm = np.array([
+            [0., 1., 2., 3., 4., 5., 6., 7., 8., 9.],
+            [1., 0., 1., 2., 3., 4., 5., 6., 7., 8.],
+            [2., 1., 0., 1., 2., 3., 4., 5., 6., 7.],
+            [3., 2., 1., 0., 1., 2., 3., 4., 5., 6.],
+            [4., 3., 2., 1., 0., 1., 2., 3., 4., 5.],
+            [5., 4., 3., 2., 1., 0., 1., 2., 3., 4.],
+            [6., 5., 4., 3., 2., 1., 0., 1., 2., 3.],
+            [7., 6., 5., 4., 3., 2., 1., 0., 1., 2.],
+            [8., 7., 6., 5., 4., 3., 2., 1., 0., 1.],
+            [9., 8., 7., 6., 5., 4., 3., 2., 1., 0.],
+        ]
+        )
+        conds = list(reversed("abcdefghij"))
+        cats  = list("ababababab")
+        rdms = RDMs(
+            np.atleast_2d(squareform(rdm)),
+            pattern_descriptors=dict(conds=conds, cats=cats)
+        )
+        rdms.sort_by(index=np.random.permutation(rdms.n_cond).tolist())  # Randomise the condition labels first
+        rdms.sort_by(conds='alpha')
+        rdms.sort_by(cats="alpha")
+        self.assertListEqual(
+            list(rdms.pattern_descriptors["conds"]),
+            list("bdfhj") + list("acegi"),
+        )
+
     def test_copy(self):
         from rsatoolbox.rdm import RDMs
         orig = RDMs(


### PR DESCRIPTION
Makes `RDMs.sort_by` sort stable by passing a stable specification to numpy.
Adds a basic test for stability.

Fixes #374.