### PR TITLE
concat sets dissimilarity_measure if it is identical for all rdms in list

### DIFF
--- a/src/rsatoolbox/rdm/rdms.py
+++ b/src/rsatoolbox/rdm/rdms.py
@@ -569,8 +569,14 @@ def concat(*rdms):
         rdm.dissimilarities
         for rdm in rdms_list
         ], axis=0)
+    # Set dissimilarity measure if it's the same for all rdms in list
+    if len(set(r.dissimilarity_measure for r in rdms_list)) == 1:
+        dissimilarity_measure = rdms_list[0].dissimilarity_measure
+    else:
+        dissimilarity_measure = None
     rdm = RDMs(
         dissimilarities=dissimilarities,
+        dissimilarity_measure=dissimilarity_measure,
         rdm_descriptors=rdm_descriptors,
         descriptors=rdms_list[0].descriptors,
         pattern_descriptors=rdms_list[0].pattern_descriptors

--- a/tests/test_rdm.py
+++ b/tests/test_rdm.py
@@ -324,6 +324,7 @@ class TestRDM(unittest.TestCase):
         rdms = concat((rdms1, rdms2))
         self.assertEqual(rdms.n_rdm, 16)
         assert len(rdms.rdm_descriptors['session']) == 16
+        self.assertEqual(rdms.dissimilarity_measure, mes)
 
     def test_concat_varargs_multiple_rdms(self):
         from rsatoolbox.rdm import concat


### PR DESCRIPTION
Checks for all dissimilarity_measures being the same and sets it if so.

Also add test for the above.

Not testing that it's not set when different.

Fixes #368.