### PR TITLE
CI: Help publish step find the binary artifacts

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,18 +22,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Download all  artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
-          path: artifacts
+          path: dist
+          merge-multiple: true
       - name: List files
-        run: ls -R artifacts
-      - name: Gather artifacts
-        run: |
-          mkdir dist
-          mv artifacts/source/*.tar.gz dist/
-          mv artifacts/wheels-macos-latest/*.whl dist/
-          mv artifacts/wheels-ubuntu-latest/*.whl dist/
-          mv artifacts/wheels-windows-latest/*.whl dist/
+        run: ls -R dist
       - name: Publish package
         uses: pypa/gh-action-pypi-publish@v1.5.1
         with:

--- a/.github/workflows/testbuild.yml
+++ b/.github/workflows/testbuild.yml
@@ -75,7 +75,7 @@ jobs:
         pip install -q twine
         twine check dist/*
     - name: Store artifact
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: source
         path: dist/*
@@ -110,7 +110,7 @@ jobs:
     - name: Store artifact
       uses: actions/upload-artifact@v4
       with:
-        name: cibw-wheels-${{ matrix.os }}-${{ strategy.job-index }}
+        name: cibw-wheels-${{ matrix.os }}
         path: dist/*.whl
         if-no-files-found: error
         retention-days: 1

--- a/.github/workflows/testbuild.yml
+++ b/.github/workflows/testbuild.yml
@@ -77,7 +77,7 @@ jobs:
     - name: Store artifact
       uses: actions/upload-artifact@v4
       with:
-        name: source
+        name: source-${{ matrix.os }}-${{ matrix.python-version }}
         path: dist/*
         if-no-files-found: error
         retention-days: 1
@@ -110,7 +110,7 @@ jobs:
     - name: Store artifact
       uses: actions/upload-artifact@v4
       with:
-        name: cibw-wheels-${{ matrix.os }}
+        name: wheels-${{ matrix.os }}
         path: dist/*.whl
         if-no-files-found: error
         retention-days: 1


### PR DESCRIPTION
The publish step cannot find the artifacts generated by the binary build steps anymore (see [this job](https://github.com/rsagroup/rsatoolbox/actions/runs/9957811147/job/27511526517)).
This attempts to change the way they are stored.