### PR TITLE
Replace deprecated `convert_to_dataset()` with `time_as_observations()`

### DIFF
--- a/demos/demo_temporal.ipynb
+++ b/demos/demo_temporal.ipynb
@@ -208,7 +208,7 @@
     "- `rsatoolbox.data.TemporalDataset.split_time(by)`\n",
     "- `rsatoolbox.data.TemporalDataset.subset_time(by, t_from, t_to)`\n",
     "- `rsatoolbox.data.TemporalDataset.bin_time(by, bins)`\n",
-    "- `rsatoolbox.data.TemporalDataset.convert_to_dataset(by)`"
+    "- `rsatoolbox.data.TemporalDataset.time_as_observations(by)`"
    ]
   },
   {
@@ -351,7 +351,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "#### `rsatoolbox.data.TemporalDataset.convert_to_dataset(by)`\n",
+    "#### `rsatoolbox.data.TemporalDataset.time_as_observations(by)`\n",
     "\n",
     "returns a `rsatoolbox.data.Dataset` object where the time dimension is absorbed into the observation dimension"
    ]
@@ -378,7 +378,7 @@
     "print('shape of original measurements')\n",
     "print(data.measurements.shape)\n",
     "\n",
-    "data_dataset = data.convert_to_dataset('time')\n",
+    "data_dataset = data.time_as_observations('time')\n",
     "\n",
     "print('\\nafter binning')\n",
     "print(data_dataset.measurements.shape)\n",

--- a/src/rsatoolbox/rdm/calc.py
+++ b/src/rsatoolbox/rdm/calc.py
@@ -169,7 +169,7 @@ def calc_rdm_movie(
 
         rdms = []
         for dat in splited_data:
-            dat_single = dat.convert_to_dataset(time_descriptor)
+            dat_single = dat.time_as_observations(time_descriptor)
             if unbalanced:
                 rdms.append(calc_rdm_unbalanced(
                     dat_single, method=method,

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -376,7 +376,7 @@ class TestTemporalDataset(unittest.TestCase):
         self.assertEqual(
             subset.time_descriptors['time'][-1], tim_des['time'][5])
 
-    def test_temporaldataset_convert_to_dataset(self):
+    def test_temporaldataset_time_as_observations(self):
         measurements = np.zeros((10, 5, 15))
         des = {'session': 0, 'subj': 0}
         obs_des = {'conds': np.array([0, 0, 1, 1, 2, 2, 2, 3, 4, 5])}
@@ -390,7 +390,7 @@ class TestTemporalDataset(unittest.TestCase):
                                             channel_descriptors=chn_des,
                                             time_descriptors=tim_des
                                             )
-        data = data_temporal.convert_to_dataset('time')
+        data = data_temporal.time_as_observations('time')
         self.assertEqual(data.n_obs, 150)
         self.assertEqual(data.n_channel, 5)
         self.assertEqual(len(data.obs_descriptors['time']), 150)

--- a/tests/test_demo.py
+++ b/tests/test_demo.py
@@ -368,7 +368,7 @@ class TestDemos(unittest.TestCase):
         print(data_binned.time_descriptors['time'][0])
         print('shape of original measurements')
         print(data.measurements.shape)
-        data_dataset = data.convert_to_dataset('time')
+        data_dataset = data.time_as_observations('time')
         print('\nafter binning')
         print(data_dataset.measurements.shape)
         print(data_dataset.obs_descriptors['time'][0])


### PR DESCRIPTION
`TemporalDataset.convert_to_dataset()` method got deprecated and replaced by `TemporalDataset.time_as_observations()` in https://github.com/rsagroup/rsatoolbox/pull/295. Yet `convert_to_dataset()` was still called on several occasions including `calc_rdm_movie()` and tests and demos. I replaced all such occurances to avoid triggering warnings.