### PR TITLE
Undo temporary blacklisting of matplotlib v3.9.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ scipy>=1.10.1
 scikit-learn
 scikit-image
 pandas
-matplotlib!=3.9.1
+matplotlib
 h5py
 tqdm
 joblib


### PR DESCRIPTION
Version 3.6.1 has now been removed in favour of the upcoming 3.6.2. To keep our requirements clean we can remove this specifier.

resolves #412 