### PR TITLE
Debug: replace `channle_descriptors` to `time_descriptors` to correct assignment

### DIFF
--- a/src/rsatoolbox/data/dataset.py
+++ b/src/rsatoolbox/data/dataset.py
@@ -807,7 +807,7 @@ class TemporalDataset(Dataset):
         data_dict['descriptors'] = self.descriptors
         data_dict['obs_descriptors'] = self.obs_descriptors
         data_dict['channel_descriptors'] = self.channel_descriptors
-        data_dict['time_descriptors'] = self.channel_descriptors
+        data_dict['time_descriptors'] = self.time_descriptors
         data_dict['type'] = type(self).__name__
         return data_dict
 


### PR DESCRIPTION
@JasperVanDenBosch 
I open this PR for [the issue](https://github.com/rsagroup/rsatoolbox/issues/419#issue-2497835907) about function `to_dict()` of class `TemporalDataset`.
I just replaced `self.channel_descriptors` to `self.time_descriptors` to debug the assignment of `data_dict` in the function `to_dict()`.