### PR TITLE
bug fix for non-functional spm_filter()

### DIFF
--- a/src/rsatoolbox/io/spm.py
+++ b/src/rsatoolbox/io/spm.py
@@ -149,6 +149,6 @@ class SpmGlm:
 
         fdata = data.copy()
         for i in range(self.nruns):
-            Y = fdata[scan_bounds[i]:scan_bounds[i+1], :]
-            Y = Y - self.filter_matrices[i] @ (self.filter_matrices[i].T @ Y)
+            start, end = scan_bounds[i], scan_bounds[i+1]
+            fdata[start:end, :] -= self.filter_matrices[i] @ (self.filter_matrices[i].T @ fdata[start:end, :])
         return fdata


### PR DESCRIPTION
spm_filter assigned fdata to Y, modified Y, and then returned fdata, suggesting Y was meant to modify fdata in place, but Y was a copy, not a view of fdata, so fdata was never updated at all and spm_filter simply returned its input unmodified. The fix implements an inplace updating of fdata instead.