### PR TITLE
Ensure remove_mean parameter is respected by calc_rdm

### DIFF
--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -7,7 +7,6 @@ on:
 permissions:
   contents: read
   statuses: write
-  pull-requests: write
 
 jobs:
 

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -7,6 +7,7 @@ on:
 permissions:
   contents: read
   statuses: write
+  pull-requests: write
 
 jobs:
 

--- a/src/rsatoolbox/rdm/calc.py
+++ b/src/rsatoolbox/rdm/calc.py
@@ -7,7 +7,7 @@ Calculation of RDMs from datasets
 from __future__ import annotations
 from collections.abc import Iterable
 from copy import deepcopy
-from typing import TYPE_CHECKING, Optional, Tuple
+from typing import TYPE_CHECKING, Optional, Tuple, List, Union
 import numpy as np
 from rsatoolbox.rdm.rdms import concat
 from rsatoolbox.rdm.calc_unbalanced import calc_rdm_unbalanced
@@ -17,6 +17,7 @@ from rsatoolbox.util.rdm_utils import _extract_triu_
 from rsatoolbox.util.build_rdm import _build_rdms
 
 if TYPE_CHECKING:
+    from rsatoolbox.rdm.rdms import RDMs
     from rsatoolbox.data.base import DatasetBase
     from numpy.typing import NDArray
 
@@ -27,9 +28,9 @@ def calc_rdm(
         descriptor: Optional[str] = None,
         noise: Optional[NDArray] = None,
         cv_descriptor: Optional[str] = None,
-        prior_lambda: float = 1,
+        prior_lambda: float = 1.0,
         prior_weight: float = 0.1,
-        remove_mean: bool = False):
+        remove_mean: bool = False) -> Union[RDMs, List[RDMs]]:
     """
     calculates an RDM from an input dataset
 
@@ -58,58 +59,58 @@ def calc_rdm(
 
     """
     if isinstance(dataset, Iterable):
-        rdms = []
+        rdms: List[RDMs] = []
         for i_dat, ds_i in enumerate(dataset):
-            if noise is None:
-                rdms.append(calc_rdm(
-                    ds_i, method=method,
-                    descriptor=descriptor,
-                    cv_descriptor=cv_descriptor,
-                    prior_lambda=prior_lambda, prior_weight=prior_weight,
-                    remove_mean=remove_mean))
-            elif isinstance(noise, np.ndarray) and noise.ndim == 2:
-                rdms.append(calc_rdm(
-                    ds_i, method=method,
-                    descriptor=descriptor,
-                    noise=noise,
-                    cv_descriptor=cv_descriptor,
-                    prior_lambda=prior_lambda, prior_weight=prior_weight,
-                    remove_mean=remove_mean))
-            elif isinstance(noise, Iterable):
-                rdms.append(calc_rdm(
-                    ds_i, method=method,
-                    descriptor=descriptor,
-                    noise=noise[i_dat],
-                    cv_descriptor=cv_descriptor,
-                    prior_lambda=prior_lambda, prior_weight=prior_weight,
-                    remove_mean=remove_mean))
+            if isinstance(noise, Iterable):
+                noise_i = noise[i_dat]
+            else:
+                noise_i = noise
+            rdms.append(_calc_rdm_single(ds_i, method, descriptor, noise_i,
+                                         cv_descriptor, prior_lambda,
+                                         prior_weight, remove_mean))
         if descriptor is None:
-            rdm = concat(rdms)
+            return concat(rdms)
         else:
-            rdm = from_partials(rdms, descriptor=descriptor)
+            return from_partials(rdms, descriptor=descriptor)
     else:
-        if method == 'euclidean':
-            rdm = calc_rdm_euclidean(dataset, descriptor, remove_mean)
-        elif method == 'correlation':
-            rdm = calc_rdm_correlation(dataset, descriptor)
-        elif method == 'mahalanobis':
-            rdm = calc_rdm_mahalanobis(dataset, descriptor, noise, remove_mean)
-        elif method == 'crossnobis':
-            rdm = calc_rdm_crossnobis(dataset, descriptor, noise,
-                                      cv_descriptor, remove_mean)
-        elif method == 'poisson':
-            rdm = calc_rdm_poisson(dataset, descriptor,
-                                   prior_lambda=prior_lambda,
-                                   prior_weight=prior_weight)
-        elif method == 'poisson_cv':
-            rdm = calc_rdm_poisson_cv(dataset, descriptor,
-                                      cv_descriptor=cv_descriptor,
-                                      prior_lambda=prior_lambda,
-                                      prior_weight=prior_weight)
-        else:
-            raise NotImplementedError
-        if descriptor is not None:
-            rdm.sort_by(**{descriptor: 'alpha'})
+        return _calc_rdm_single(dataset, method, descriptor, noise,
+                                cv_descriptor, prior_lambda,
+                                prior_weight, remove_mean)
+
+
+def _calc_rdm_single(
+        dataset: DatasetBase,
+        method: str,
+        descriptor: Optional[str],
+        noise: Optional[NDArray],
+        cv_descriptor: Optional[str],
+        prior_lambda: float,
+        prior_weight: float,
+        remove_mean: bool) -> RDMs:
+    """Create RDMs object for a single Dataset
+    """
+    if method == 'euclidean':
+        rdm = calc_rdm_euclidean(dataset, descriptor, remove_mean)
+    elif method == 'correlation':
+        rdm = calc_rdm_correlation(dataset, descriptor)
+    elif method == 'mahalanobis':
+        rdm = calc_rdm_mahalanobis(dataset, descriptor, noise, remove_mean)
+    elif method == 'crossnobis':
+        rdm = calc_rdm_crossnobis(dataset, descriptor, noise,
+                                    cv_descriptor, remove_mean)
+    elif method == 'poisson':
+        rdm = calc_rdm_poisson(dataset, descriptor,
+                                prior_lambda=prior_lambda,
+                                prior_weight=prior_weight)
+    elif method == 'poisson_cv':
+        rdm = calc_rdm_poisson_cv(dataset, descriptor,
+                                    cv_descriptor=cv_descriptor,
+                                    prior_lambda=prior_lambda,
+                                    prior_weight=prior_weight)
+    else:
+        raise NotImplementedError
+    if descriptor is not None:
+        rdm.sort_by(reindex=True, **{descriptor: 'alpha'})
     return rdm
 
 
@@ -388,7 +389,7 @@ def calc_rdm_crossnobis(dataset, descriptor, noise=None,
     )
 
 
-def calc_rdm_poisson(dataset, descriptor=None, prior_lambda=1,
+def calc_rdm_poisson(dataset, descriptor=None, prior_lambda=1.0,
                      prior_weight=0.1):
     """
     calculates an RDM from an input dataset using the symmetrized
@@ -417,7 +418,7 @@ def calc_rdm_poisson(dataset, descriptor=None, prior_lambda=1,
     return _build_rdms(rdm, dataset, 'poisson', descriptor, desc)
 
 
-def calc_rdm_poisson_cv(dataset, descriptor=None, prior_lambda=1,
+def calc_rdm_poisson_cv(dataset, descriptor=None, prior_lambda=1.0,
                         prior_weight=0.1, cv_descriptor=None):
     """
     calculates an RDM from an input dataset using the crossvalidated

--- a/src/rsatoolbox/rdm/calc.py
+++ b/src/rsatoolbox/rdm/calc.py
@@ -65,21 +65,24 @@ def calc_rdm(
                     ds_i, method=method,
                     descriptor=descriptor,
                     cv_descriptor=cv_descriptor,
-                    prior_lambda=prior_lambda, prior_weight=prior_weight))
+                    prior_lambda=prior_lambda, prior_weight=prior_weight,
+                    remove_mean=remove_mean))
             elif isinstance(noise, np.ndarray) and noise.ndim == 2:
                 rdms.append(calc_rdm(
                     ds_i, method=method,
                     descriptor=descriptor,
                     noise=noise,
                     cv_descriptor=cv_descriptor,
-                    prior_lambda=prior_lambda, prior_weight=prior_weight))
+                    prior_lambda=prior_lambda, prior_weight=prior_weight,
+                    remove_mean=remove_mean))
             elif isinstance(noise, Iterable):
                 rdms.append(calc_rdm(
                     ds_i, method=method,
                     descriptor=descriptor,
                     noise=noise[i_dat],
                     cv_descriptor=cv_descriptor,
-                    prior_lambda=prior_lambda, prior_weight=prior_weight))
+                    prior_lambda=prior_lambda, prior_weight=prior_weight,
+                    remove_mean=remove_mean))
         if descriptor is None:
             rdm = concat(rdms)
         else:

--- a/src/rsatoolbox/rdm/rdms.py
+++ b/src/rsatoolbox/rdm/rdms.py
@@ -6,7 +6,7 @@ Definition of RSA RDMs class and subclasses
 @author: baihan
 """
 from __future__ import annotations
-from typing import Dict, Optional
+from typing import Dict, Optional, List
 import warnings
 from copy import deepcopy
 from collections.abc import Iterable
@@ -543,7 +543,7 @@ def load_rdm(filename, file_type=None):
     return rdms_from_dict(rdm_dict)
 
 
-def concat(*rdms: RDMs, target_pdesc: Optional[str] = None) -> RDMs:
+def concat(rdms: List[RDMs], target_pdesc: Optional[str] = None) -> RDMs:
     """Merge into single RDMs object
     requires that the rdms have the same shape
     descriptor and pattern descriptors are taken from the first rdms object

--- a/src/rsatoolbox/rdm/rdms.py
+++ b/src/rsatoolbox/rdm/rdms.py
@@ -6,7 +6,7 @@ Definition of RSA RDMs class and subclasses
 @author: baihan
 """
 from __future__ import annotations
-from typing import Dict, Optional, List
+from typing import Dict, Optional
 import warnings
 from copy import deepcopy
 from collections.abc import Iterable
@@ -543,7 +543,7 @@ def load_rdm(filename, file_type=None):
     return rdms_from_dict(rdm_dict)
 
 
-def concat(rdms: List[RDMs], target_pdesc: Optional[str] = None) -> RDMs:
+def concat(rdms, target_pdesc: Optional[str] = None) -> RDMs:
     """Merge into single RDMs object
     requires that the rdms have the same shape
     descriptor and pattern descriptors are taken from the first rdms object

--- a/src/rsatoolbox/rdm/rdms.py
+++ b/src/rsatoolbox/rdm/rdms.py
@@ -6,7 +6,7 @@ Definition of RSA RDMs class and subclasses
 @author: baihan
 """
 from __future__ import annotations
-from typing import Dict, Optional
+from typing import Dict, Optional, Union, List, overload
 import warnings
 from copy import deepcopy
 from collections.abc import Iterable
@@ -542,8 +542,15 @@ def load_rdm(filename, file_type=None):
         raise ValueError('filetype not understood')
     return rdms_from_dict(rdm_dict)
 
+@overload
+def concat(*rdms:  List[RDMs], target_pdesc: Optional[str] = None) -> RDMs:
+    ...
 
-def concat(rdms, target_pdesc: Optional[str] = None) -> RDMs:
+@overload
+def concat(*rdms: RDMs, target_pdesc: Optional[str] = None) -> RDMs:
+    ...
+
+def concat(*rdms, target_pdesc: Optional[str] = None) -> RDMs:
     """Merge into single RDMs object
     requires that the rdms have the same shape
     descriptor and pattern descriptors are taken from the first rdms object


### PR DESCRIPTION
As mentioned in #448 calc_rdm does not pass through the remove_mean parameter when recursing on Dataset iterables. This minor patch corrects that.