### PR TITLE
Fix cv assignment in calc.py

### DIFF
--- a/src/rsatoolbox/rdm/calc.py
+++ b/src/rsatoolbox/rdm/calc.py
@@ -385,7 +385,7 @@ def calc_rdm_crossnobis(dataset, descriptor, noise=None,
         'crossnobis',
         descriptor,
         noise=noise,
-        cv=cv_descriptor
+        cv=np.array(datasetCopy.obs_descriptors[cv_descriptor])
     )
 
 

--- a/src/rsatoolbox/rdm/calc.py
+++ b/src/rsatoolbox/rdm/calc.py
@@ -385,7 +385,7 @@ def calc_rdm_crossnobis(dataset, descriptor, noise=None,
         'crossnobis',
         descriptor,
         noise=noise,
-        cv=np.array(datasetCopy.obs_descriptors[cv_descriptor])
+        cv=cv_descriptor
     )
 
 

--- a/src/rsatoolbox/util/build_rdm.py
+++ b/src/rsatoolbox/util/build_rdm.py
@@ -20,7 +20,7 @@ def _build_rdms(
             method: str,
             obs_desc_name: str | None,
             obs_desc_vals: Optional[NDArray] = None,
-            cv: Optional[NDArray] = None,
+            cv: Optional[str] = None,
             noise: Optional[NDArray] = None
         ) -> RDMs:
     rdms = RDMs(


### PR DESCRIPTION
_build_rdms expects this to be the actual fold assignment list, not the descriptor name. Converted it to an NDArray to match the type hint in build_rdm.py.