### PR TITLE
Fixes #466: Add optional boundary truncation for searchlights

### DIFF
--- a/tests/test_searchlight.py
+++ b/tests/test_searchlight.py
@@ -56,3 +56,91 @@ class TestSearchlight(unittest.TestCase):
         sl_RDMs = get_searchlight_RDMs(data_2d, centers, neighbors, events)
 
         assert sl_RDMs.dissimilarities.shape == (2, 10)
+
+    def test_boundary_truncation_disabled(self):
+        """Test that truncate_at_boundary=False includes voxels outside mask (default behavior)"""
+        from rsatoolbox.util.searchlight import _get_searchlight_neighbors
+
+        # Create a mask where only center voxel is True
+        mask = np.zeros((5, 5, 5), dtype=bool)
+        mask[2, 2, 2] = True
+        center = [2, 2, 2]
+        radius = 2
+
+        # With truncation disabled, should include all voxels within radius
+        neighbors = _get_searchlight_neighbors(mask, center, radius=radius, truncate_at_boundary=False)
+
+        # A radius of 2 should give 27 voxels (including those outside mask)
+        assert np.array(neighbors).shape == (3, 27)
+        # Only 1 of the 27 voxels is in the mask
+        assert np.sum(mask[neighbors]) == 1
+
+    def test_boundary_truncation_enabled(self):
+        """Test that truncate_at_boundary=True filters out voxels outside mask"""
+        from rsatoolbox.util.searchlight import _get_searchlight_neighbors
+
+        # Create a mask where only center voxel is True
+        mask = np.zeros((5, 5, 5), dtype=bool)
+        mask[2, 2, 2] = True
+        center = [2, 2, 2]
+        radius = 2
+
+        # With truncation enabled, should only include voxels where mask is True
+        neighbors = _get_searchlight_neighbors(mask, center, radius=radius, truncate_at_boundary=True)
+
+        # Should only include the 1 voxel where mask is True
+        assert np.array(neighbors).shape == (3, 1)
+        # All returned voxels should be in the mask
+        assert np.all(mask[neighbors])
+
+    def test_boundary_truncation_partial_mask(self):
+        """Test truncation with a partial mask (boundary case)"""
+        from rsatoolbox.util.searchlight import _get_searchlight_neighbors
+
+        # Create a mask with a cross pattern
+        mask = np.zeros((5, 5, 5), dtype=bool)
+        mask[2, 2, :] = True  # line along z axis
+        mask[2, :, 2] = True  # line along y axis
+        mask[:, 2, 2] = True  # line along x axis
+        center = [2, 2, 2]
+        radius = 2
+
+        # Without truncation
+        neighbors_no_trunc = _get_searchlight_neighbors(mask, center, radius=radius, truncate_at_boundary=False)
+        n_voxels_no_trunc = np.array(neighbors_no_trunc).shape[1]
+
+        # With truncation
+        neighbors_trunc = _get_searchlight_neighbors(mask, center, radius=radius, truncate_at_boundary=True)
+        n_voxels_trunc = np.array(neighbors_trunc).shape[1]
+
+        # Truncated should have fewer voxels
+        assert n_voxels_trunc < n_voxels_no_trunc
+        # All truncated voxels should be in the mask
+        assert np.all(mask[neighbors_trunc])
+        # Not all non-truncated voxels should be in the mask
+        assert not np.all(mask[neighbors_no_trunc])
+
+    def test_get_volume_searchlight_with_truncation(self):
+        """Test that get_volume_searchlight passes truncation parameter correctly"""
+        from rsatoolbox.util.searchlight import get_volume_searchlight
+
+        # Create a simple mask
+        mask = np.zeros((5, 5, 5), dtype=int)
+        mask[1:4, 1:4, 1:4] = 1  # 3x3x3 cube in the center
+
+        # Test with truncation disabled (default)
+        centers_no_trunc, _ = get_volume_searchlight(
+            mask, radius=1, threshold=0.5, truncate_at_boundary=False)
+
+        # Test with truncation enabled
+        centers_trunc, neighbors_trunc = get_volume_searchlight(
+            mask, radius=1, threshold=0.5, truncate_at_boundary=True)
+
+        # Should find centers in both cases
+        assert len(centers_no_trunc) > 0
+        assert len(centers_trunc) > 0
+
+        # With truncation, all neighbor voxels should be in the mask
+        for neighbors in neighbors_trunc:
+            neighbor_coords = np.unravel_index(neighbors, mask.shape)
+            assert np.all(mask[neighbor_coords] == 1)


### PR DESCRIPTION
# Add optional boundary truncation for searchlights
Followup PR on #466.

When computing searchlight volumes in `util/searchlight.py` with the `threshold` <100% the untruncated volumes produce misleading artefacts:
<img width="2999" height="866" alt="image" src="https://github.com/user-attachments/assets/3b3d6d94-acbd-4b65-b46e-1821eaa1a70c" />

With this optional argument we can still use <100% thresholding values and not include noise outside of the mask in the RDMs

New usage:
```python
get_volume_searchlight(mask, ..., truncate_at_boundary=True)
```

## Important TODOs
Since the varying size of the searchlight volumes are going to change the statistics there are future TODOs that would fully support this feature. Namely:
- Searchlight Size Tracking through metadata
- Propagate Size Info Through RDMs
  - The weighting scheme requires deciding:
  - How does variance scale with number of voxels?
  - Linear? Square root?
  - Does it depend on the correlation structure? 
- Accordingly modify functions in `inference/evaluate.py` and `inference/result.py`
