### PR TITLE
solve issue for saving different noise sizes in saving RDMs

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -14,7 +14,7 @@
 #
 import os
 import sys
-from pkg_resources import get_distribution
+from importlib.metadata import version
 sys.path.insert(0, os.path.abspath('.'))
 sys.path.insert(0, os.path.abspath('../'))
 
@@ -25,7 +25,7 @@ copyright = '2023, rsatoolbox authors'
 author = 'rsatoolbox authors'
 
 # The full version
-release = get_distribution('rsatoolbox').version
+release = version("rsatoolbox")
 
 # The short X.Y version
 version = '.'.join(release.split('.')[:2])

--- a/src/rsatoolbox/io/hdf5.py
+++ b/src/rsatoolbox/io/hdf5.py
@@ -1,10 +1,12 @@
 """
 saving to and reading from HDF5 files
 """
+
 from __future__ import annotations
 from typing import Union, Dict, List, IO
 import os
 from collections.abc import Iterable
+
 try:  # drop:py37 (backport)
     from importlib.metadata import version
 except ModuleNotFoundError:
@@ -14,7 +16,7 @@ import numpy as np
 
 
 def write_dict_hdf5(fhandle: Union[str, IO], dictionary: Dict) -> None:
-    """ writes a nested dictionary containing strings & arrays as data into
+    """writes a nested dictionary containing strings & arrays as data into
     a hdf5 file
 
     Args:
@@ -24,14 +26,14 @@ def write_dict_hdf5(fhandle: Union[str, IO], dictionary: Dict) -> None:
     """
     if isinstance(fhandle, str):
         if os.path.exists(fhandle):
-            raise ValueError('File already exists!')
-    file = File(fhandle, 'a')
-    file.attrs['rsatoolbox_version'] = version('rsatoolbox')
+            raise ValueError("File already exists!")
+    file = File(fhandle, "a")
+    file.attrs["rsatoolbox_version"] = version("rsatoolbox")
     _write_to_group(file, dictionary)
 
 
 def _write_to_group(group: Group, dictionary: Dict) -> None:
-    """ writes a dictionary to a hdf5 group, which can recurse"""
+    """writes a dictionary to a hdf5 group, which can recurse"""
     for key in dictionary.keys():
         value = dictionary[key]
         if isinstance(value, str):
@@ -39,8 +41,8 @@ def _write_to_group(group: Group, dictionary: Dict) -> None:
             # like numpy.str_
             group.attrs[key] = str(value)
         elif isinstance(value, np.ndarray):
-            if str(value.dtype)[:2] == '<U':
-                group[key] = value.astype('S')
+            if str(value.dtype)[:2] == "<U":
+                group[key] = value.astype("S")
             else:
                 group[key] = value
         elif isinstance(value, list):
@@ -72,18 +74,22 @@ def _write_list(group: Group, key: str, value: List) -> None:
     """
     try:
         value = np.array(value)
-        if str(value.dtype)[:2] == '<U':
-            group[key] = value.astype('S')
+        if str(value.dtype)[:2] == "<U":
+            group[key] = value.astype("S")
         else:
             group[key] = value
     except TypeError:
         l_group = group.create_group(key)
         for i, v in enumerate(value):
             l_group[str(i)] = v
+    except ValueError:
+        l_group = group.create_group(key)
+        for i, v in enumerate(value):
+            l_group[str(i)] = v
 
 
 def read_dict_hdf5(fhandle: Union[str, IO]) -> Dict:
-    """ writes a nested dictionary containing strings & arrays as data into
+    """writes a nested dictionary containing strings & arrays as data into
     a hdf5 file
 
     Args:
@@ -93,12 +99,12 @@ def read_dict_hdf5(fhandle: Union[str, IO]) -> Dict:
         dictionary(dict): the loaded dict
 
     """
-    file = File(fhandle, 'r')
+    file = File(fhandle, "r")
     return _read_group(file)
 
 
 def _read_group(group: Group) -> Dict:
-    """ reads a group from a hdf5 file into a dict, which allows recursion"""
+    """reads a group from a hdf5 file into a dict, which allows recursion"""
     dictionary = {}
     for key in group.keys():
         sub_val = group[key]
@@ -109,7 +115,7 @@ def _read_group(group: Group) -> Dict:
         else:
             dictionary[key] = np.array(sub_val)
             if dictionary[key].dtype.type is np.bytes_:
-                dictionary[key] = np.array(sub_val).astype('unicode')
+                dictionary[key] = np.array(sub_val).astype("unicode")
             # if (len(dictionary[key].shape) == 1
             #     and dictionary[key].shape[0] == 1):
             #     dictionary[key] = dictionary[key][0]

--- a/src/rsatoolbox/rdm/rdms.py
+++ b/src/rsatoolbox/rdm/rdms.py
@@ -6,7 +6,7 @@ Definition of RSA RDMs class and subclasses
 @author: baihan
 """
 from __future__ import annotations
-from typing import Dict, Optional, Union, List, overload
+from typing import Dict, Optional, Union, List, overload, IO
 import warnings
 from copy import deepcopy
 from collections.abc import Iterable
@@ -30,7 +30,7 @@ from rsatoolbox.util.file_io import remove_file
 
 
 class RDMs:
-    """ RDMs class
+    """RDMs class
 
     Args:
         dissimilarities (numpy.ndarray):
@@ -50,19 +50,22 @@ class RDMs:
         n_cond(int): number of patterns
 
     """
+
     dissimilarities: np.ndarray
     dissimilarity_measure: Optional[str]
     descriptors: Dict
     rdm_descriptors: Dict
     pattern_descriptors: Dict
 
-    def __init__(self, dissimilarities,
-                 dissimilarity_measure=None,
-                 descriptors=None,
-                 rdm_descriptors=None,
-                 pattern_descriptors=None):
-        self.dissimilarities, self.n_rdm, self.n_cond = \
-            batch_to_vectors(dissimilarities)
+    def __init__(
+        self,
+        dissimilarities,
+        dissimilarity_measure=None,
+        descriptors=None,
+        rdm_descriptors=None,
+        pattern_descriptors=None,
+    ):
+        self.dissimilarities, self.n_rdm, self.n_cond = batch_to_vectors(dissimilarities)
         if descriptors is None:
             self.descriptors = {}
         else:
@@ -73,9 +76,7 @@ class RDMs:
             for k, v in rdm_descriptors.items():
                 if not isinstance(v, Iterable) or isinstance(v, str):
                     rdm_descriptors[k] = [v]
-            check_descriptor_length_error(rdm_descriptors,
-                                          'rdm_descriptors',
-                                          self.n_rdm)
+            check_descriptor_length_error(rdm_descriptors, "rdm_descriptors", self.n_rdm)
             self.rdm_descriptors = rdm_descriptors
         if pattern_descriptors is None:
             self.pattern_descriptors = {}
@@ -83,27 +84,26 @@ class RDMs:
             for k, v in pattern_descriptors.items():
                 if not isinstance(v, Iterable) or isinstance(v, str):
                     pattern_descriptors[k] = [v]
-            check_descriptor_length_error(pattern_descriptors,
-                                          'pattern_descriptors',
-                                          self.n_cond)
+            check_descriptor_length_error(pattern_descriptors, "pattern_descriptors", self.n_cond)
             self.pattern_descriptors = pattern_descriptors
-        if 'index' not in self.pattern_descriptors.keys():
-            self.pattern_descriptors['index'] = list(range(self.n_cond))
-        if 'index' not in self.rdm_descriptors.keys():
-            self.rdm_descriptors['index'] = list(range(self.n_rdm))
+        if "index" not in self.pattern_descriptors.keys():
+            self.pattern_descriptors["index"] = list(range(self.n_cond))
+        if "index" not in self.rdm_descriptors.keys():
+            self.rdm_descriptors["index"] = list(range(self.n_rdm))
         self.dissimilarity_measure = dissimilarity_measure
 
     def __repr__(self):
         """
         defines string which is printed for the object
         """
-        return (f'rsatoolbox.rdm.{self.__class__.__name__}(\n'
-                f'dissimilarity_measure = \n{self.dissimilarity_measure}\n'
-                f'dissimilarities = \n{self.dissimilarities}\n'
-                f'descriptors = \n{self.descriptors}\n'
-                f'rdm_descriptors = \n{self.rdm_descriptors}\n'
-                f'pattern_descriptors = \n{self.pattern_descriptors}\n'
-                )
+        return (
+            f"rsatoolbox.rdm.{self.__class__.__name__}(\n"
+            f"dissimilarity_measure = \n{self.dissimilarity_measure}\n"
+            f"dissimilarities = \n{self.dissimilarities}\n"
+            f"descriptors = \n{self.descriptors}\n"
+            f"rdm_descriptors = \n{self.rdm_descriptors}\n"
+            f"pattern_descriptors = \n{self.pattern_descriptors}\n"
+        )
 
     def __eq__(self, other: object) -> bool:
         """Test for equality
@@ -120,12 +120,14 @@ class RDMs:
             bool: True if equal
         """
         if isinstance(other, RDMs):
-            return all([
-                np.all(self.dissimilarities == other.dissimilarities),
-                self.descriptors == other.descriptors,
-                desc_eq(self.rdm_descriptors, other.rdm_descriptors),
-                desc_eq(self.pattern_descriptors, other.pattern_descriptors),
-            ])
+            return all(
+                [
+                    np.all(self.dissimilarities == other.dissimilarities),
+                    self.descriptors == other.descriptors,
+                    desc_eq(self.rdm_descriptors, other.rdm_descriptors),
+                    desc_eq(self.pattern_descriptors, other.pattern_descriptors),
+                ]
+            )
         return False
 
     def __str__(self):
@@ -136,14 +138,15 @@ class RDMs:
         rdm_desc = format_descriptor(self.rdm_descriptors)
         pattern_desc = format_descriptor(self.pattern_descriptors)
         diss = self.get_matrices()[0]
-        return (f'rsatoolbox.rdm.{self.__class__.__name__}\n'
-                f'{self.n_rdm} RDM(s) over {self.n_cond} conditions\n\n'
-                f'dissimilarity_measure = \n{self.dissimilarity_measure}\n\n'
-                f'dissimilarities[0] = \n{diss}\n\n'
-                f'descriptors: \n{string_desc}\n'
-                f'rdm_descriptors: \n{rdm_desc}\n'
-                f'pattern_descriptors: \n{pattern_desc}\n'
-                )
+        return (
+            f"rsatoolbox.rdm.{self.__class__.__name__}\n"
+            f"{self.n_rdm} RDM(s) over {self.n_cond} conditions\n\n"
+            f"dissimilarity_measure = \n{self.dissimilarity_measure}\n\n"
+            f"dissimilarities[0] = \n{diss}\n\n"
+            f"descriptors: \n{string_desc}\n"
+            f"rdm_descriptors: \n{rdm_desc}\n"
+            f"pattern_descriptors: \n{pattern_desc}\n"
+        )
 
     def __getitem__(self, idx):
         """
@@ -151,13 +154,16 @@ class RDMs:
         and iterating over RDMs with `for rdm in rdms:`
         """
         dissimilarities = self.dissimilarities[np.array(idx)].reshape(
-            -1, self.dissimilarities.shape[1])
+            -1, self.dissimilarities.shape[1]
+        )
         rdm_descriptors = subset_descriptor(self.rdm_descriptors, idx)
-        rdms = RDMs(dissimilarities,
-                    dissimilarity_measure=self.dissimilarity_measure,
-                    descriptors=self.descriptors,
-                    rdm_descriptors=rdm_descriptors,
-                    pattern_descriptors=self.pattern_descriptors)
+        rdms = RDMs(
+            dissimilarities,
+            dissimilarity_measure=self.dissimilarity_measure,
+            descriptors=self.descriptors,
+            rdm_descriptors=rdm_descriptors,
+            pattern_descriptors=self.pattern_descriptors,
+        )
         return rdms
 
     def __len__(self) -> int:
@@ -168,7 +174,7 @@ class RDMs:
         return self.n_rdm
 
     def get_vectors(self):
-        """ Returns RDMs as np.ndarray with each RDM as a vector
+        """Returns RDMs as np.ndarray with each RDM as a vector
 
         Returns:
             numpy.ndarray: RDMs as a matrix with one row per RDM
@@ -177,7 +183,7 @@ class RDMs:
         return self.dissimilarities
 
     def get_matrices(self):
-        """ Returns RDMs as np.ndarray with each RDM as a matrix
+        """Returns RDMs as np.ndarray with each RDM as a matrix
 
         Returns:
             numpy.ndarray: RDMs as a 3-Tensor with one matrix per RDM
@@ -198,11 +204,11 @@ class RDMs:
             dissimilarity_measure=self.dissimilarity_measure,
             descriptors=deepcopy(self.descriptors),
             rdm_descriptors=deepcopy(self.rdm_descriptors),
-            pattern_descriptors=deepcopy(self.pattern_descriptors)
+            pattern_descriptors=deepcopy(self.pattern_descriptors),
         )
 
     def subset_pattern(self, by, value):
-        """ Returns a smaller RDMs with patterns with certain descriptor values
+        """Returns a smaller RDMs with patterns with certain descriptor values
 
         Args:
             by(String): the descriptor by which the subset selection
@@ -215,29 +221,29 @@ class RDMs:
 
         """
         if by is None:
-            by = 'index'
+            by = "index"
         if not isinstance(value, Iterable):
             value = [value]
         selection = num_index(self.pattern_descriptors[by], value)
         ix, iy = np.triu_indices(self.n_cond, 1)
-        pattern_in_value = np.array(
-            [p in value for p in self.pattern_descriptors[by]])
+        pattern_in_value = np.array([p in value for p in self.pattern_descriptors[by]])
         selection_xy = pattern_in_value[ix] & pattern_in_value[iy]
         dissimilarities = self.dissimilarities[:, selection_xy]
         descriptors = self.descriptors
-        pattern_descriptors = extract_dict(
-            self.pattern_descriptors, selection)
+        pattern_descriptors = extract_dict(self.pattern_descriptors, selection)
         rdm_descriptors = self.rdm_descriptors
         dissimilarity_measure = self.dissimilarity_measure
-        rdms = RDMs(dissimilarities=dissimilarities,
-                    descriptors=descriptors,
-                    rdm_descriptors=rdm_descriptors,
-                    pattern_descriptors=pattern_descriptors,
-                    dissimilarity_measure=dissimilarity_measure)
+        rdms = RDMs(
+            dissimilarities=dissimilarities,
+            descriptors=descriptors,
+            rdm_descriptors=rdm_descriptors,
+            pattern_descriptors=pattern_descriptors,
+            dissimilarity_measure=dissimilarity_measure,
+        )
         return rdms
 
     def subsample_pattern(self, by, value):
-        """ Returns a subsampled RDMs with repetitions if values are repeated
+        """Returns a subsampled RDMs with repetitions if values are repeated
 
         This function now generates Nans where the off-diagonal 0s would
         appear. These values are trivial to predict for models and thus
@@ -254,11 +260,10 @@ class RDMs:
 
         """
         if by is None:
-            by = 'index'
+            by = "index"
         desc = np.array(self.pattern_descriptors[by])  # desc is list-like
         if isinstance(value, (list, tuple, np.ndarray)):
-            selection = [np.asarray(desc == i).nonzero()[0]
-                         for i in value]
+            selection = [np.asarray(desc == i).nonzero()[0] for i in value]
             selection = np.concatenate(selection)
         else:
             selection = np.where(desc == value)[0]
@@ -269,19 +274,20 @@ class RDMs:
         selection = np.sort(selection)
         dissimilarities = dissimilarities[:, selection][:, :, selection]
         descriptors = self.descriptors
-        pattern_descriptors = extract_dict(
-            self.pattern_descriptors, selection)
+        pattern_descriptors = extract_dict(self.pattern_descriptors, selection)
         rdm_descriptors = self.rdm_descriptors
         dissimilarity_measure = self.dissimilarity_measure
-        rdms = RDMs(dissimilarities=dissimilarities,
-                    descriptors=descriptors,
-                    rdm_descriptors=rdm_descriptors,
-                    pattern_descriptors=pattern_descriptors,
-                    dissimilarity_measure=dissimilarity_measure)
+        rdms = RDMs(
+            dissimilarities=dissimilarities,
+            descriptors=descriptors,
+            rdm_descriptors=rdm_descriptors,
+            pattern_descriptors=pattern_descriptors,
+            dissimilarity_measure=dissimilarity_measure,
+        )
         return rdms
 
     def subset(self, by, value):
-        """ Returns a set of fewer RDMs matching descriptor values
+        """Returns a set of fewer RDMs matching descriptor values
 
         Args:
             by(String): the descriptor by which the subset selection
@@ -294,22 +300,24 @@ class RDMs:
 
         """
         if by is None:
-            by = 'index'
+            by = "index"
         selection = num_index(self.rdm_descriptors[by], value)
         dissimilarities = self.dissimilarities[selection, :]
         descriptors = self.descriptors
         pattern_descriptors = self.pattern_descriptors
         rdm_descriptors = extract_dict(self.rdm_descriptors, selection)
         dissimilarity_measure = self.dissimilarity_measure
-        rdms = RDMs(dissimilarities=dissimilarities,
-                    descriptors=descriptors,
-                    rdm_descriptors=rdm_descriptors,
-                    pattern_descriptors=pattern_descriptors,
-                    dissimilarity_measure=dissimilarity_measure)
+        rdms = RDMs(
+            dissimilarities=dissimilarities,
+            descriptors=descriptors,
+            rdm_descriptors=rdm_descriptors,
+            pattern_descriptors=pattern_descriptors,
+            dissimilarity_measure=dissimilarity_measure,
+        )
         return rdms
 
     def subsample(self, by, value):
-        """ Returns a subsampled RDMs with repetitions if values are repeated
+        """Returns a subsampled RDMs with repetitions if values are repeated
 
         Args:
             by(String): the descriptor by which the subset selection
@@ -322,7 +330,7 @@ class RDMs:
 
         """
         if by is None:
-            by = 'index'
+            by = "index"
         desc = self.rdm_descriptors[by]
         selection = []
         if isinstance(value, (list, tuple, np.ndarray)):
@@ -339,15 +347,17 @@ class RDMs:
         pattern_descriptors = self.pattern_descriptors
         rdm_descriptors = extract_dict(self.rdm_descriptors, selection)
         dissimilarity_measure = self.dissimilarity_measure
-        rdms = RDMs(dissimilarities=dissimilarities,
-                    descriptors=descriptors,
-                    rdm_descriptors=rdm_descriptors,
-                    pattern_descriptors=pattern_descriptors,
-                    dissimilarity_measure=dissimilarity_measure)
+        rdms = RDMs(
+            dissimilarities=dissimilarities,
+            descriptors=descriptors,
+            rdm_descriptors=rdm_descriptors,
+            pattern_descriptors=pattern_descriptors,
+            dissimilarity_measure=dissimilarity_measure,
+        )
         return rdms
 
     def append(self, rdm):
-        """ appends an rdm to the object
+        """appends an rdm to the object
         The rdm should have the same shape and type as this object.
         Its pattern_descriptor and descriptor are ignored
 
@@ -357,18 +367,17 @@ class RDMs:
         Returns:
 
         """
-        assert isinstance(rdm, RDMs), 'appended rdm should be an RDMs'
-        assert rdm.n_cond == self.n_cond, 'appended rdm had wrong shape'
-        assert rdm.dissimilarity_measure == self.dissimilarity_measure, \
-            'appended rdm had wrong dissimilarity measure'
-        self.dissimilarities = np.concatenate((
-            self.dissimilarities, rdm.dissimilarities), axis=0)
-        self.rdm_descriptors = append_descriptor(self.rdm_descriptors,
-                                                 rdm.rdm_descriptors)
+        assert isinstance(rdm, RDMs), "appended rdm should be an RDMs"
+        assert rdm.n_cond == self.n_cond, "appended rdm had wrong shape"
+        assert (
+            rdm.dissimilarity_measure == self.dissimilarity_measure
+        ), "appended rdm had wrong dissimilarity measure"
+        self.dissimilarities = np.concatenate((self.dissimilarities, rdm.dissimilarities), axis=0)
+        self.rdm_descriptors = append_descriptor(self.rdm_descriptors, rdm.rdm_descriptors)
         self.n_rdm = self.n_rdm + rdm.n_rdm
 
-    def save(self, filename, file_type='hdf5', overwrite=False):
-        """ saves the RDMs object into a file
+    def save(self, filename, file_type="hdf5", overwrite=False):
+        """saves the RDMs object into a file
 
         Args:
             filename(String): path to file to save to
@@ -382,24 +391,24 @@ class RDMs:
         rdm_dict = self.to_dict()
         if overwrite:
             remove_file(filename)
-        if file_type == 'hdf5':
+        if file_type == "hdf5":
             write_dict_hdf5(filename, rdm_dict)
-        elif file_type == 'pkl':
+        elif file_type == "pkl":
             write_dict_pkl(filename, rdm_dict)
 
     def to_dict(self):
-        """ converts the object into a dictionary, which can be saved to disk
+        """converts the object into a dictionary, which can be saved to disk
 
         Returns:
             rdm_dict(dict): dictionary containing all information required to
                 recreate the RDMs object
         """
         rdm_dict = {}
-        rdm_dict['dissimilarities'] = self.dissimilarities
-        rdm_dict['descriptors'] = self.descriptors
-        rdm_dict['rdm_descriptors'] = self.rdm_descriptors
-        rdm_dict['pattern_descriptors'] = self.pattern_descriptors
-        rdm_dict['dissimilarity_measure'] = self.dissimilarity_measure
+        rdm_dict["dissimilarities"] = self.dissimilarities
+        rdm_dict["descriptors"] = self.descriptors
+        rdm_dict["rdm_descriptors"] = self.rdm_descriptors
+        rdm_dict["pattern_descriptors"] = self.pattern_descriptors
+        rdm_dict["dissimilarity_measure"] = self.dissimilarity_measure
         return rdm_dict
 
     def to_df(self):
@@ -459,22 +468,24 @@ class RDMs:
             ValueError: Raised if the method chosen is not implemented
         """
         for dname, method in kwargs.items():
-            if method == 'alpha':
+            if method == "alpha":
                 descriptor = self.pattern_descriptors[dname]
-                self.reorder(np.argsort(descriptor, kind='stable'))
+                self.reorder(np.argsort(descriptor, kind="stable"))
             elif isinstance(method, (list, np.ndarray)):
                 # in this case, `method` is the desired descriptor order
                 new_order = method
                 descriptor = self.pattern_descriptors[dname]
                 if not set(descriptor).issubset(new_order):
-                    raise ValueError(f'Expected {method} to be a permutation \
-                            or subset of {descriptor}')
+                    raise ValueError(
+                        f"Expected {method} to be a permutation \
+                            or subset of {descriptor}"
+                    )
                 # convert to indices to use `reorder` method
                 self.reorder([list(descriptor).index(x) for x in new_order])
             else:
-                raise ValueError(f'Unknown sorting method: {method}')
+                raise ValueError(f"Unknown sorting method: {method}")
         if reindex:
-            self.pattern_descriptors['index'] = list(range(self.n_cond))
+            self.pattern_descriptors["index"] = list(range(self.n_cond))
 
     def mean(self, weights=None):
         """Average rdm of all rdms contained
@@ -489,9 +500,7 @@ class RDMs:
             `rsatoolbox.rdm.rdms.RDMs`: New RDMs object with one vector
         """
         if str(weights) in self.rdm_descriptors:
-            new_descriptors = {
-                (k, v) for (k, v) in self.descriptors.items() if k != weights
-            }
+            new_descriptors = {(k, v) for (k, v) in self.descriptors.items() if k != weights}
             weights = self.rdm_descriptors[weights]
         else:
             new_descriptors = deepcopy(self.descriptors)
@@ -499,12 +508,12 @@ class RDMs:
             dissimilarities=np.array([_mean(self.dissimilarities, weights)]),
             dissimilarity_measure=self.dissimilarity_measure,
             descriptors=new_descriptors,
-            pattern_descriptors=deepcopy(self.pattern_descriptors)
+            pattern_descriptors=deepcopy(self.pattern_descriptors),
         )
 
 
 def rdms_from_dict(rdm_dict):
-    """ creates a RDMs object from a dictionary
+    """creates a RDMs object from a dictionary
 
     Args:
         rdm_dict(dict): dictionary with information
@@ -513,42 +522,50 @@ def rdms_from_dict(rdm_dict):
         rdms(RDMs): the regenerated RDMs object
 
     """
-    rdms = RDMs(dissimilarities=rdm_dict['dissimilarities'],
-                descriptors=rdm_dict['descriptors'],
-                rdm_descriptors=dict_to_list(rdm_dict['rdm_descriptors']),
-                pattern_descriptors=dict_to_list(rdm_dict['pattern_descriptors']),
-                dissimilarity_measure=rdm_dict['dissimilarity_measure'])
+    rdms = RDMs(
+        dissimilarities=rdm_dict["dissimilarities"],
+        descriptors=rdm_dict["descriptors"],
+        rdm_descriptors=dict_to_list(rdm_dict["rdm_descriptors"]),
+        pattern_descriptors=dict_to_list(rdm_dict["pattern_descriptors"]),
+        dissimilarity_measure=rdm_dict["dissimilarity_measure"],
+    )
     return rdms
 
 
-def load_rdm(filename, file_type=None):
-    """ loads a RDMs object from disk
+def load_rdm(filename: Union[str, IO], file_type: Optional[str] = None) -> RDMs:
+    """loads a RDMs object from disk
 
     Args:
-        filename(String): path to file to load
+        filename(String): path to file to load or open file
+        file_type(String): Type of file to load:
+            "hdf5": hdf5 file
+            "pkl": pickle file
+            the file type is optional for filenames,
+            for which the type is inferred from the file extension
 
     """
     if file_type is None:
         if isinstance(filename, str):
-            if filename[-4:] == '.pkl':
-                file_type = 'pkl'
-            elif filename[-3:] == '.h5' or filename[-4:] == 'hdf5':
-                file_type = 'hdf5'
-    if file_type == 'hdf5':
+            if filename[-4:] == ".pkl":
+                file_type = "pkl"
+            elif filename[-3:] == ".h5" or filename[-4:] == "hdf5":
+                file_type = "hdf5"
+    if file_type == "hdf5":
         rdm_dict = read_dict_hdf5(filename)
-    elif file_type == 'pkl':
+    elif file_type == "pkl":
         rdm_dict = read_dict_pkl(filename)
     else:
-        raise ValueError('filetype not understood')
+        raise ValueError("filetype not understood")
     return rdms_from_dict(rdm_dict)
 
-@overload
-def concat(*rdms:  List[RDMs], target_pdesc: Optional[str] = None) -> RDMs:
-    ...
 
 @overload
-def concat(*rdms: RDMs, target_pdesc: Optional[str] = None) -> RDMs:
-    ...
+def concat(*rdms: List[RDMs], target_pdesc: Optional[str] = None) -> RDMs: ...
+
+
+@overload
+def concat(*rdms: RDMs, target_pdesc: Optional[str] = None) -> RDMs: ...
+
 
 def concat(*rdms, target_pdesc: Optional[str] = None) -> RDMs:
     """Merge into single RDMs object
@@ -566,42 +583,51 @@ def concat(*rdms, target_pdesc: Optional[str] = None) -> RDMs:
         rsatoolbox.rdm.RDMs: concatenated rdms object
 
     """
-    if len(rdms) == 1: ## single argument
+    if len(rdms) == 1:  # single argument
         if isinstance(rdms[0], RDMs):
             rdms_list = [rdms[0]]
         else:
             rdms_list = list(rdms[0])
-    else: ## multiple arguments
+    else:  # multiple arguments
         rdms_list = list(rdms)
-    assert isinstance(rdms_list[0], RDMs), \
-        'Supply list of RDMs objects, or RDMs objects as separate arguments'
+    assert isinstance(
+        rdms_list[0], RDMs
+    ), "Supply list of RDMs objects, or RDMs objects as separate arguments"
 
     descriptors, rdm_descriptors = _merged_rdm_descriptors(rdms_list)
 
     if target_pdesc is None:
         # see if we can find an authoritative descriptor for pattern order
         pdescs = rdms_list[0].pattern_descriptors.keys()
-        pdesc_candidates = list(filter(
-            lambda n: n != 'index' and (
-                len(rdms_list[0].pattern_descriptors[n])
-                == len(set(rdms_list[0].pattern_descriptors[n]))),
-                pdescs))
+        pdesc_candidates = list(
+            filter(
+                lambda n: n != "index"
+                and (
+                    len(rdms_list[0].pattern_descriptors[n])
+                    == len(set(rdms_list[0].pattern_descriptors[n]))
+                ),
+                pdescs,
+            )
+        )
         target_pdesc = None
         if len(pdesc_candidates) > 0:
             target_pdesc = pdesc_candidates[0]
         if len(pdesc_candidates) > 1:
             warnings.warn(f'[concat] Multiple pattern descriptors found, using "{target_pdesc}"')
     else:
-        assert target_pdesc in rdms_list[0].pattern_descriptors.keys(), \
-            'The provided descriptor is not a pattern descriptor'
-        assert len(rdms_list[0].pattern_descriptors[target_pdesc]) == rdms_list[0].n_cond, \
-            'The provided descriptor is not unique'
+        assert (
+            target_pdesc in rdms_list[0].pattern_descriptors.keys()
+        ), "The provided descriptor is not a pattern descriptor"
+        assert (
+            len(rdms_list[0].pattern_descriptors[target_pdesc]) == rdms_list[0].n_cond
+        ), "The provided descriptor is not unique"
 
     for rdm_new in rdms_list[1:]:
-        assert isinstance(rdm_new, RDMs), 'rdm for concat should be an RDMs'
-        assert rdm_new.n_cond == rdms_list[0].n_cond, 'rdm for concat had wrong shape'
-        assert rdm_new.dissimilarity_measure == rdms_list[0].dissimilarity_measure, \
-            'appended rdm had wrong dissimilarity measure'
+        assert isinstance(rdm_new, RDMs), "rdm for concat should be an RDMs"
+        assert rdm_new.n_cond == rdms_list[0].n_cond, "rdm for concat had wrong shape"
+        assert (
+            rdm_new.dissimilarity_measure == rdms_list[0].dissimilarity_measure
+        ), "appended rdm had wrong dissimilarity measure"
         if target_pdesc:
             # if we have a target descriptor, check if the order is the same
             auth_order = rdms_list[0].pattern_descriptors[target_pdesc]
@@ -611,10 +637,7 @@ def concat(*rdms, target_pdesc: Optional[str] = None) -> RDMs:
                 _, new_order = np.where(auth_order[:, None] == other_order)
                 rdm_new.reorder(new_order)
 
-    dissimilarities = np.concatenate([
-        rdm.dissimilarities
-        for rdm in rdms_list
-        ], axis=0)
+    dissimilarities = np.concatenate([rdm.dissimilarities for rdm in rdms_list], axis=0)
     # Set dissimilarity measure if it's the same for all rdms in list
     if len(set(r.dissimilarity_measure for r in rdms_list)) == 1:
         dissimilarity_measure = rdms_list[0].dissimilarity_measure
@@ -625,13 +648,13 @@ def concat(*rdms, target_pdesc: Optional[str] = None) -> RDMs:
         dissimilarity_measure=dissimilarity_measure,
         rdm_descriptors=rdm_descriptors,
         descriptors=descriptors,
-        pattern_descriptors=rdms_list[0].pattern_descriptors
+        pattern_descriptors=rdms_list[0].pattern_descriptors,
     )
     return rdm
 
 
 def permute_rdms(rdms, p=None):
-    """ Permute rows, columns and corresponding pattern descriptors
+    """Permute rows, columns and corresponding pattern descriptors
     of RDM matrices according to a permutation vector
 
     Args:
@@ -647,14 +670,15 @@ def permute_rdms(rdms, p=None):
     """
     if p is None:
         p = np.random.permutation(rdms.n_cond)
-        print('No permutation vector specified,'
-              + ' performing random permutation.')
+        print("No permutation vector specified," + " performing random permutation.")
 
-    assert p.dtype == 'int', "permutation vector must have integer entries."
-    assert min(p) == 0 and max(p) == rdms.n_cond-1, \
-        "permutation vector must have entries ranging from 0 to n_cond"
-    assert len(np.unique(p)) == rdms.n_cond, \
-        "permutation vector must only have unique integer entries"
+    assert p.dtype == "int", "permutation vector must have integer entries."
+    assert (
+        min(p) == 0 and max(p) == rdms.n_cond - 1
+    ), "permutation vector must have entries ranging from 0 to n_cond"
+    assert (
+        len(np.unique(p)) == rdms.n_cond
+    ), "permutation vector must only have unique integer entries"
 
     rdm_mats = rdms.get_matrices()
     descriptors = rdms.descriptors.copy()
@@ -663,30 +687,31 @@ def permute_rdms(rdms, p=None):
 
     # To easily reverse permutation later
     p_inv = np.arange(len(p))[np.argsort(p)]
-    descriptors.update({'p_inv': p_inv})
+    descriptors.update({"p_inv": p_inv})
     rdm_mats = rdm_mats[:, p, :]
     rdm_mats = rdm_mats[:, :, p]
-    stims = np.array(pattern_descriptors['index'])
-    pattern_descriptors.update({'index': list(stims[p].astype(np.str_))})
+    stims = np.array(pattern_descriptors["index"])
+    pattern_descriptors.update({"index": list(stims[p].astype(np.str_))})
 
     rdms_p = RDMs(
         dissimilarities=rdm_mats,
         descriptors=descriptors,
         rdm_descriptors=rdm_descriptors,
-        pattern_descriptors=pattern_descriptors)
+        pattern_descriptors=pattern_descriptors,
+    )
     return rdms_p
 
 
 def inverse_permute_rdms(rdms):
-    """ Gimmick function to reverse the effect of permute_rdms() """
+    """Gimmick function to reverse the effect of permute_rdms()"""
 
-    p_inv = rdms.descriptors['p_inv']
+    p_inv = rdms.descriptors["p_inv"]
     rdms_p = permute_rdms(rdms, p=p_inv)
     return rdms_p
 
 
-def get_categorical_rdm(category_vector, category_name='category'):
-    """ generates an RDM object containing a categorical RDM, i.e. RDM = 0
+def get_categorical_rdm(category_vector, category_name="category"):
+    """generates an RDM object containing a categorical RDM, i.e. RDM = 0
     if the category is the same and 1 if they are different
 
     Args:
@@ -703,13 +728,15 @@ def get_categorical_rdm(category_vector, category_name='category'):
     for i_cat in range(n):
         for j_cat in range(i_cat + 1, n):
             if isinstance(category_vector[i_cat], Iterable):
-                comparisons = [np.array(category_vector[i_cat][idx])
-                               != np.array(category_vector[j_cat][idx])
-                               for idx in range(len(category_vector[i_cat]))]
+                comparisons = [
+                    np.array(category_vector[i_cat][idx]) != np.array(category_vector[j_cat][idx])
+                    for idx in range(len(category_vector[i_cat]))
+                ]
                 rdm_list.append(np.any(comparisons))
             else:
-                rdm_list.append(
-                    category_vector[i_cat] != category_vector[j_cat])
-    rdm = RDMs(np.array(rdm_list, dtype=float),
-               pattern_descriptors={category_name: np.array(category_vector)})
+                rdm_list.append(category_vector[i_cat] != category_vector[j_cat])
+    rdm = RDMs(
+        np.array(rdm_list, dtype=float),
+        pattern_descriptors={category_name: np.array(category_vector)},
+    )
     return rdm

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -260,7 +260,6 @@ class TestConsistency(unittest.TestCase):
             rdm_no_normalized = model_weighted.predict(theta_no_normalized)
             assert compare(rdm, rdm_no_normalized) > 0.999
 
-
     def test_two_rdms_nn(self):
         from rsatoolbox.model import ModelInterpolate, ModelWeighted
         from rsatoolbox.model.fitter import fit_regress_nn, fit_optimize_positive

--- a/tests/test_rdm.py
+++ b/tests/test_rdm.py
@@ -23,30 +23,24 @@ class TestRDM(unittest.TestCase):
     def test_rdm3d_init(self):
         dis = np.zeros((8, 5, 5))
         mes = "Euclidean"
-        des = {'session': 0, 'subj': 0}
-        rdms = rsr.RDMs(dissimilarities=dis,
-                        dissimilarity_measure=mes,
-                        descriptors=des)
+        des = {"session": 0, "subj": 0}
+        rdms = rsr.RDMs(dissimilarities=dis, dissimilarity_measure=mes, descriptors=des)
         self.assertEqual(rdms.n_rdm, 8)
         self.assertEqual(rdms.n_cond, 5)
 
     def test_rdm2d_init(self):
         dis = np.zeros((8, 10))
         mes = "Euclidean"
-        des = {'session': 0, 'subj': 0}
-        rdms = rsr.RDMs(dissimilarities=dis,
-                        dissimilarity_measure=mes,
-                        descriptors=des)
+        des = {"session": 0, "subj": 0}
+        rdms = rsr.RDMs(dissimilarities=dis, dissimilarity_measure=mes, descriptors=des)
         self.assertEqual(rdms.n_rdm, 8)
         self.assertEqual(rdms.n_cond, 5)
 
     def test_rdm3d_get_vectors(self):
         dis = np.zeros((8, 5, 5))
         mes = "Euclidean"
-        des = {'session': 0, 'subj': 0}
-        rdms = rsr.RDMs(dissimilarities=dis,
-                        dissimilarity_measure=mes,
-                        descriptors=des)
+        des = {"session": 0, "subj": 0}
+        rdms = rsr.RDMs(dissimilarities=dis, dissimilarity_measure=mes, descriptors=des)
         v_rdms = rdms.get_vectors()
         self.assertEqual(v_rdms.shape[0], 8)
         self.assertEqual(v_rdms.shape[1], 10)
@@ -54,10 +48,8 @@ class TestRDM(unittest.TestCase):
     def test_rdm2d_get_vectors(self):
         dis = np.zeros((8, 10))
         mes = "Euclidean"
-        des = {'session': 0, 'subj': 0}
-        rdms = rsr.RDMs(dissimilarities=dis,
-                        dissimilarity_measure=mes,
-                        descriptors=des)
+        des = {"session": 0, "subj": 0}
+        rdms = rsr.RDMs(dissimilarities=dis, dissimilarity_measure=mes, descriptors=des)
         v_rdms = rdms.get_vectors()
         self.assertEqual(v_rdms.shape[0], 8)
         self.assertEqual(v_rdms.shape[1], 10)
@@ -65,10 +57,8 @@ class TestRDM(unittest.TestCase):
     def test_rdm3d_get_matrices(self):
         dis = np.zeros((8, 5, 5))
         mes = "Euclidean"
-        des = {'session': 0, 'subj': 0}
-        rdms = rsr.RDMs(dissimilarities=dis,
-                        dissimilarity_measure=mes,
-                        descriptors=des)
+        des = {"session": 0, "subj": 0}
+        rdms = rsr.RDMs(dissimilarities=dis, dissimilarity_measure=mes, descriptors=des)
         m_rdms = rdms.get_matrices()
         self.assertEqual(m_rdms.shape[0], 8)
         self.assertEqual(m_rdms.shape[1], 5)
@@ -77,10 +67,8 @@ class TestRDM(unittest.TestCase):
     def test_rdm2d_get_matrices(self):
         dis = np.zeros((8, 10))
         mes = "Euclidean"
-        des = {'session': 0, 'subj': 0}
-        rdms = rsr.RDMs(dissimilarities=dis,
-                        dissimilarity_measure=mes,
-                        descriptors=des)
+        des = {"session": 0, "subj": 0}
+        rdms = rsr.RDMs(dissimilarities=dis, dissimilarity_measure=mes, descriptors=des)
         m_rdms = rdms.get_matrices()
         self.assertEqual(m_rdms.shape[0], 8)
         self.assertEqual(m_rdms.shape[1], 5)
@@ -89,73 +77,72 @@ class TestRDM(unittest.TestCase):
     def test_rdm_subset(self):
         dis = np.zeros((8, 10))
         mes = "Euclidean"
-        des = {'subj': 0}
-        rdm_des = {'session': np.array([0, 1, 2, 2, 4, 5, 6, 7])}
-        rdms = rsr.RDMs(dissimilarities=dis,
-                        rdm_descriptors=rdm_des,
-                        dissimilarity_measure=mes,
-                        descriptors=des)
-        rdms_subset = rdms.subset('session', np.array([0, 1, 2]))
+        des = {"subj": 0}
+        rdm_des = {"session": np.array([0, 1, 2, 2, 4, 5, 6, 7])}
+        rdms = rsr.RDMs(
+            dissimilarities=dis, rdm_descriptors=rdm_des, dissimilarity_measure=mes, descriptors=des
+        )
+        rdms_subset = rdms.subset("session", np.array([0, 1, 2]))
         self.assertEqual(rdms_subset.n_rdm, 4)
         self.assertEqual(rdms_subset.n_cond, 5)
-        assert_array_equal(rdms_subset.rdm_descriptors['session'],
-                           [0, 1, 2, 2])
+        assert_array_equal(rdms_subset.rdm_descriptors["session"], [0, 1, 2, 2])
 
     def test_rdm_subset_pattern(self):
         dis = np.zeros((8, 10))
         mes = "Euclidean"
-        des = {'subj': 0}
-        pattern_des = {'type': np.array([0, 1, 2, 2, 4])}
-        rdms = rsr.RDMs(dissimilarities=dis,
-                        pattern_descriptors=pattern_des,
-                        dissimilarity_measure=mes,
-                        descriptors=des)
-        rdms_subset = rdms.subset_pattern('type', np.array([0, 1, 2]))
+        des = {"subj": 0}
+        pattern_des = {"type": np.array([0, 1, 2, 2, 4])}
+        rdms = rsr.RDMs(
+            dissimilarities=dis,
+            pattern_descriptors=pattern_des,
+            dissimilarity_measure=mes,
+            descriptors=des,
+        )
+        rdms_subset = rdms.subset_pattern("type", np.array([0, 1, 2]))
         self.assertEqual(rdms_subset.n_rdm, 8)
         self.assertEqual(rdms_subset.n_cond, 4)
-        assert_array_equal(rdms_subset.pattern_descriptors['type'],
-                           [0, 1, 2, 2])
+        assert_array_equal(rdms_subset.pattern_descriptors["type"], [0, 1, 2, 2])
 
     def test_rdm_subsample(self):
         dis = np.zeros((8, 10))
         mes = "Euclidean"
-        des = {'subj': 0}
-        rdm_des = {'session': np.array([0, 1, 2, 2, 4, 5, 6, 7])}
-        rdms = rsr.RDMs(dissimilarities=dis,
-                        rdm_descriptors=rdm_des,
-                        dissimilarity_measure=mes,
-                        descriptors=des)
-        rdms_sample = rdms.subsample('session', np.array([0, 1, 2, 2]))
+        des = {"subj": 0}
+        rdm_des = {"session": np.array([0, 1, 2, 2, 4, 5, 6, 7])}
+        rdms = rsr.RDMs(
+            dissimilarities=dis, rdm_descriptors=rdm_des, dissimilarity_measure=mes, descriptors=des
+        )
+        rdms_sample = rdms.subsample("session", np.array([0, 1, 2, 2]))
         self.assertEqual(rdms_sample.n_rdm, 6)
         self.assertEqual(rdms_sample.n_cond, 5)
-        assert_array_equal(rdms_sample.rdm_descriptors['session'],
-                           [0, 1, 2, 2, 2, 2])
+        assert_array_equal(rdms_sample.rdm_descriptors["session"], [0, 1, 2, 2, 2, 2])
 
     def test_rdm_subsample_pattern(self):
         dis = np.zeros((8, 10))
         mes = "Euclidean"
-        des = {'subj': 0}
-        pattern_des = {'type': np.array([0, 1, 2, 2, 4])}
-        rdms = rsr.RDMs(dissimilarities=dis,
-                        pattern_descriptors=pattern_des,
-                        dissimilarity_measure=mes,
-                        descriptors=des)
-        rdms_sample = rdms.subsample_pattern('type',
-                                             np.array([0, 1, 2, 2]))
+        des = {"subj": 0}
+        pattern_des = {"type": np.array([0, 1, 2, 2, 4])}
+        rdms = rsr.RDMs(
+            dissimilarities=dis,
+            pattern_descriptors=pattern_des,
+            dissimilarity_measure=mes,
+            descriptors=des,
+        )
+        rdms_sample = rdms.subsample_pattern("type", np.array([0, 1, 2, 2]))
         self.assertEqual(rdms_sample.n_rdm, 8)
         self.assertEqual(rdms_sample.n_cond, 6)
-        assert_array_equal(rdms_sample.pattern_descriptors['type'],
-                           [0, 1, 2, 2, 2, 2])
+        assert_array_equal(rdms_sample.pattern_descriptors["type"], [0, 1, 2, 2, 2, 2])
 
     def test_rdm_idx(self):
         dis = np.zeros((8, 10))
         mes = "Euclidean"
-        des = {'subj': 0}
-        pattern_des = {'type': np.array([0, 1, 2, 2, 4])}
-        rdms = rsr.RDMs(dissimilarities=dis,
-                        pattern_descriptors=pattern_des,
-                        dissimilarity_measure=mes,
-                        descriptors=des)
+        des = {"subj": 0}
+        pattern_des = {"type": np.array([0, 1, 2, 2, 4])}
+        rdms = rsr.RDMs(
+            dissimilarities=dis,
+            pattern_descriptors=pattern_des,
+            dissimilarity_measure=mes,
+            descriptors=des,
+        )
         rdms_sample = rdms[2]
         self.assertEqual(rdms_sample.n_rdm, 1)
         assert_array_equal(rdms_sample.dissimilarities[0], dis[2])
@@ -166,45 +153,45 @@ class TestRDM(unittest.TestCase):
     def test_rdm_len(self):
         n_rdm, n_cond = 7, 10
         dis = np.zeros((n_rdm, n_cond, n_cond))
-        rdms = rsr.RDMs(dissimilarities=dis,
-                        pattern_descriptors={
-                            'type': np.array(list(range(n_cond)))},
-                        dissimilarity_measure='Euclidean',
-                        descriptors={'subj': range(n_rdm)})
+        rdms = rsr.RDMs(
+            dissimilarities=dis,
+            pattern_descriptors={"type": np.array(list(range(n_cond)))},
+            dissimilarity_measure="Euclidean",
+            descriptors={"subj": range(n_rdm)},
+        )
         self.assertEqual(len(rdms), n_rdm)
 
     def test_rdm_idx_len_is_1(self):
         n_rdm, n_cond = 7, 10
         dis = np.zeros((n_rdm, n_cond, n_cond))
-        rdms = rsr.RDMs(dissimilarities=dis,
-                        pattern_descriptors={
-                            'type': np.array(list(range(n_cond)))},
-                        dissimilarity_measure='Euclidean',
-                        descriptors={'subj': range(n_rdm)})
+        rdms = rsr.RDMs(
+            dissimilarities=dis,
+            pattern_descriptors={"type": np.array(list(range(n_cond)))},
+            dissimilarity_measure="Euclidean",
+            descriptors={"subj": range(n_rdm)},
+        )
         self.assertEqual(len(rdms[0]), 1)
 
     def test_rdm_subset_len(self):
         subset_idxs = [0, 1, 2]
         dis = np.zeros((8, 10))
         mes = "Euclidean"
-        des = {'subj': 0}
-        rdm_des = {'session': np.array([0, 1, 2, 3, 4, 5, 6, 7])}
-        rdms = rsr.RDMs(dissimilarities=dis,
-                        rdm_descriptors=rdm_des,
-                        dissimilarity_measure=mes,
-                        descriptors=des)
-        rdms_subset = rdms.subset('session', np.array(subset_idxs))
+        des = {"subj": 0}
+        rdm_des = {"session": np.array([0, 1, 2, 3, 4, 5, 6, 7])}
+        rdms = rsr.RDMs(
+            dissimilarities=dis, rdm_descriptors=rdm_des, dissimilarity_measure=mes, descriptors=des
+        )
+        rdms_subset = rdms.subset("session", np.array(subset_idxs))
         self.assertEqual(len(rdms_subset), len(subset_idxs))
 
     def test_rdm_iter(self):
         dis = np.zeros((8, 10))
         mes = "Euclidean"
-        des = {'subj': 0}
-        rdm_des = {'session': np.array([0, 1, 2, 2, 4, 5, 6, 7])}
-        rdms = rsr.RDMs(dissimilarities=dis,
-                        rdm_descriptors=rdm_des,
-                        dissimilarity_measure=mes,
-                        descriptors=des)
+        des = {"subj": 0}
+        rdm_des = {"session": np.array([0, 1, 2, 2, 4, 5, 6, 7])}
+        rdms = rsr.RDMs(
+            dissimilarities=dis, rdm_descriptors=rdm_des, dissimilarity_measure=mes, descriptors=des
+        )
         i = 0
         for rdm in rdms:
             self.assertIsInstance(rdm, rsr.RDMs)
@@ -215,19 +202,22 @@ class TestRDM(unittest.TestCase):
 
     def test_transform(self):
         from rsatoolbox.rdm import transform
+
         dis = self.rng.random((8, 10))
         mes = "Euclidean"
-        des = {'subj': 0}
-        pattern_des = {'type': np.array([0, 1, 2, 2, 4])}
-        rdm_des = {'session': np.array([0, 1, 2, 2, 4, 5, 6, 7])}
-        rdms = rsr.RDMs(dissimilarities=dis,
-                        rdm_descriptors=rdm_des,
-                        pattern_descriptors=pattern_des,
-                        dissimilarity_measure=mes,
-                        descriptors=des)
+        des = {"subj": 0}
+        pattern_des = {"type": np.array([0, 1, 2, 2, 4])}
+        rdm_des = {"session": np.array([0, 1, 2, 2, 4, 5, 6, 7])}
+        rdms = rsr.RDMs(
+            dissimilarities=dis,
+            rdm_descriptors=rdm_des,
+            pattern_descriptors=pattern_des,
+            dissimilarity_measure=mes,
+            descriptors=des,
+        )
 
         def square(x):
-            return x ** 2
+            return x**2
 
         transformed_rdm = transform(rdms, square)
         self.assertEqual(transformed_rdm.n_rdm, rdms.n_rdm)
@@ -236,48 +226,56 @@ class TestRDM(unittest.TestCase):
     def test_rank_transform(self):
         from rsatoolbox.rdm.transform import rank_transform
         from rsatoolbox.rdm.rdms import RDMs
+
         rdms = RDMs(
             dissimilarities=np.array([[8, 6, 10, np.nan]]),
             dissimilarity_measure="Euclidean",
         )
         rank_rdm = rank_transform(rdms)
-        self.assertEqual(rank_rdm.dissimilarity_measure, 'Euclidean (ranks)')
+        self.assertEqual(rank_rdm.dissimilarity_measure, "Euclidean (ranks)")
         assert_array_equal(rank_rdm.dissimilarities, [[2, 1, 3, np.nan]])
 
     def test_rank_transform_unknown_measure(self):
         from rsatoolbox.rdm import rank_transform
+
         rdms = rsr.RDMs(dissimilarities=np.zeros((8, 10)))
         rank_rdm = rank_transform(rdms)
-        self.assertEqual(rank_rdm.dissimilarity_measure, '(ranks)')
+        self.assertEqual(rank_rdm.dissimilarity_measure, "(ranks)")
 
     def test_sqrt_transform(self):
         from rsatoolbox.rdm import sqrt_transform
+
         dis = np.zeros((8, 10))
         mes = "Euclidean"
-        des = {'subj': 0}
-        pattern_des = {'type': np.array([0, 1, 2, 2, 4])}
-        rdm_des = {'session': np.array([0, 1, 2, 2, 4, 5, 6, 7])}
-        rdms = rsr.RDMs(dissimilarities=dis,
-                        rdm_descriptors=rdm_des,
-                        pattern_descriptors=pattern_des,
-                        dissimilarity_measure=mes,
-                        descriptors=des)
+        des = {"subj": 0}
+        pattern_des = {"type": np.array([0, 1, 2, 2, 4])}
+        rdm_des = {"session": np.array([0, 1, 2, 2, 4, 5, 6, 7])}
+        rdms = rsr.RDMs(
+            dissimilarities=dis,
+            rdm_descriptors=rdm_des,
+            pattern_descriptors=pattern_des,
+            dissimilarity_measure=mes,
+            descriptors=des,
+        )
         sqrt_rdm = sqrt_transform(rdms)
         self.assertEqual(sqrt_rdm.n_rdm, rdms.n_rdm)
         self.assertEqual(sqrt_rdm.n_cond, rdms.n_cond)
 
     def test_positive_transform(self):
         from rsatoolbox.rdm import positive_transform
+
         dis = self.rng.random((8, 10)) - 0.5
         mes = "Euclidean"
-        des = {'subj': 0}
-        pattern_des = {'type': np.array([0, 1, 2, 2, 4])}
-        rdm_des = {'session': np.array([0, 1, 2, 2, 4, 5, 6, 7])}
-        rdms = rsr.RDMs(dissimilarities=dis,
-                        rdm_descriptors=rdm_des,
-                        pattern_descriptors=pattern_des,
-                        dissimilarity_measure=mes,
-                        descriptors=des)
+        des = {"subj": 0}
+        pattern_des = {"type": np.array([0, 1, 2, 2, 4])}
+        rdm_des = {"session": np.array([0, 1, 2, 2, 4, 5, 6, 7])}
+        rdms = rsr.RDMs(
+            dissimilarities=dis,
+            rdm_descriptors=rdm_des,
+            pattern_descriptors=pattern_des,
+            dissimilarity_measure=mes,
+            descriptors=des,
+        )
         pos_rdm = positive_transform(rdms)
         self.assertEqual(pos_rdm.n_rdm, rdms.n_rdm)
         self.assertEqual(pos_rdm.n_cond, rdms.n_cond)
@@ -285,48 +283,57 @@ class TestRDM(unittest.TestCase):
 
     def test_minmax_transform(self):
         from rsatoolbox.rdm import minmax_transform
+
         dis = np.zeros((8, 10))
         mes = "Euclidean"
-        des = {'subj': 0}
-        pattern_des = {'type': np.array([0, 1, 2, 2, 4])}
-        rdm_des = {'session': np.array([0, 1, 2, 2, 4, 5, 6, 7])}
-        rdms = rsr.RDMs(dissimilarities=dis,
-                        rdm_descriptors=rdm_des,
-                        pattern_descriptors=pattern_des,
-                        dissimilarity_measure=mes,
-                        descriptors=des)
+        des = {"subj": 0}
+        pattern_des = {"type": np.array([0, 1, 2, 2, 4])}
+        rdm_des = {"session": np.array([0, 1, 2, 2, 4, 5, 6, 7])}
+        rdms = rsr.RDMs(
+            dissimilarities=dis,
+            rdm_descriptors=rdm_des,
+            pattern_descriptors=pattern_des,
+            dissimilarity_measure=mes,
+            descriptors=des,
+        )
         mm_rdm = minmax_transform(rdms)
         self.assertEqual(mm_rdm.n_rdm, rdms.n_rdm)
         self.assertEqual(mm_rdm.n_cond, rdms.n_cond)
 
     def test_geotopological_transform(self):
         from rsatoolbox.rdm import geotopological_transform
+
         dis = np.zeros((8, 10))
         mes = "Euclidean"
-        des = {'subj': 0}
-        pattern_des = {'type': np.array([0, 1, 2, 2, 4])}
-        rdm_des = {'session': np.array([0, 1, 2, 2, 4, 5, 6, 7])}
-        rdms = rsr.RDMs(dissimilarities=dis,
-                        rdm_descriptors=rdm_des,
-                        pattern_descriptors=pattern_des,
-                        dissimilarity_measure=mes,
-                        descriptors=des)
+        des = {"subj": 0}
+        pattern_des = {"type": np.array([0, 1, 2, 2, 4])}
+        rdm_des = {"session": np.array([0, 1, 2, 2, 4, 5, 6, 7])}
+        rdms = rsr.RDMs(
+            dissimilarities=dis,
+            rdm_descriptors=rdm_des,
+            pattern_descriptors=pattern_des,
+            dissimilarity_measure=mes,
+            descriptors=des,
+        )
         gt_rdm = geotopological_transform(rdms, low=0.2, up=0.8)
         self.assertEqual(gt_rdm.n_rdm, rdms.n_rdm)
         self.assertEqual(gt_rdm.n_cond, rdms.n_cond)
 
     def test_geodesic_transform(self):
         from rsatoolbox.rdm import geodesic_transform
+
         dis = np.random.rand(8, 10)
         mes = "Euclidean"
-        des = {'subj': 0}
-        pattern_des = {'type': np.array([0, 1, 2, 2, 4])}
-        rdm_des = {'session': np.array([0, 1, 2, 2, 4, 5, 6, 7])}
-        rdms = rsr.RDMs(dissimilarities=dis,
-                        rdm_descriptors=rdm_des,
-                        pattern_descriptors=pattern_des,
-                        dissimilarity_measure=mes,
-                        descriptors=des)
+        des = {"subj": 0}
+        pattern_des = {"type": np.array([0, 1, 2, 2, 4])}
+        rdm_des = {"session": np.array([0, 1, 2, 2, 4, 5, 6, 7])}
+        rdms = rsr.RDMs(
+            dissimilarities=dis,
+            rdm_descriptors=rdm_des,
+            pattern_descriptors=pattern_des,
+            dissimilarity_measure=mes,
+            descriptors=des,
+        )
         gd_rdm = geodesic_transform(rdms)
         self.assertEqual(gd_rdm.n_rdm, rdms.n_rdm)
         self.assertEqual(gd_rdm.n_cond, rdms.n_cond)
@@ -334,87 +341,83 @@ class TestRDM(unittest.TestCase):
     def test_rdm_append(self):
         dis = np.zeros((8, 10))
         mes = "Euclidean"
-        des = {'subj': 0}
-        pattern_des = {'type': np.array([0, 1, 2, 2, 4])}
-        rdm_des = {'session': np.array([0, 1, 2, 2, 4, 5, 6, 7])}
-        rdms = rsr.RDMs(dissimilarities=dis,
-                        pattern_descriptors=pattern_des,
-                        dissimilarity_measure=mes,
-                        descriptors=des,
-                        rdm_descriptors=rdm_des)
+        des = {"subj": 0}
+        pattern_des = {"type": np.array([0, 1, 2, 2, 4])}
+        rdm_des = {"session": np.array([0, 1, 2, 2, 4, 5, 6, 7])}
+        rdms = rsr.RDMs(
+            dissimilarities=dis,
+            pattern_descriptors=pattern_des,
+            dissimilarity_measure=mes,
+            descriptors=des,
+            rdm_descriptors=rdm_des,
+        )
         rdms.append(rdms)
         self.assertEqual(rdms.n_rdm, 16)
 
     def test_concat(self):
         from rsatoolbox.rdm import concat
+
         rdms1 = rsr.RDMs(
             dissimilarities=np.array([[2, 1, 3, 1, 1, 2]]),
-            pattern_descriptors=dict(cond=np.array(['a', 'c', 'b', 'd'])),
-            dissimilarity_measure='euclidean',
-            descriptors=dict(subject='zoe', exp='foo'),
-            rdm_descriptors=dict(session=[1])
+            pattern_descriptors=dict(cond=np.array(["a", "c", "b", "d"])),
+            dissimilarity_measure="euclidean",
+            descriptors=dict(subject="zoe", exp="foo"),
+            rdm_descriptors=dict(session=[1]),
         )
         rdms2 = rsr.RDMs(
             dissimilarities=np.array([[2, 4, 6, 2, 4, 2]]),
-            pattern_descriptors=dict(cond=np.array(['a', 'b', 'c', 'd'])),
-            dissimilarity_measure='euclidean',
-            descriptors=dict(subject='joe', exp='foo'),
-            rdm_descriptors=dict(session=[3])
+            pattern_descriptors=dict(cond=np.array(["a", "b", "c", "d"])),
+            dissimilarity_measure="euclidean",
+            descriptors=dict(subject="joe", exp="foo"),
+            rdm_descriptors=dict(session=[3]),
         )
         rdms3 = rsr.RDMs(
-            dissimilarities=np.array([
-                [3,   9,  6,  6,  3,  3],
-                [13, 19, 16, 16, 13, 13]
-            ]),
-            pattern_descriptors=dict(cond=np.array(['d', 'c', 'a', 'b'])),
-            dissimilarity_measure='euclidean',
-            descriptors=dict(subject='max', exp='foo'),
-            rdm_descriptors=dict(session=[5, 7])
+            dissimilarities=np.array([[3, 9, 6, 6, 3, 3], [13, 19, 16, 16, 13, 13]]),
+            pattern_descriptors=dict(cond=np.array(["d", "c", "a", "b"])),
+            dissimilarity_measure="euclidean",
+            descriptors=dict(subject="max", exp="foo"),
+            rdm_descriptors=dict(session=[5, 7]),
         )
         rdms = concat([rdms1, rdms2, rdms3])
         self.assertEqual(rdms.n_rdm, 4)
-        self.assertEqual(rdms.dissimilarity_measure, 'euclidean')
-        self.assertEqual(rdms.descriptors['exp'], 'foo')
-        assert_array_equal(
-            rdms.rdm_descriptors['session'],
-            [1, 3, 5, 7]
-        )
-        assert_array_equal(
-            rdms.rdm_descriptors['subject'],
-            ['zoe', 'joe', 'max', 'max']
-        )
-        assert_array_equal(
-            rdms.pattern_descriptors['cond'],
-            ['a', 'c', 'b', 'd']
-        )
+        self.assertEqual(rdms.dissimilarity_measure, "euclidean")
+        self.assertEqual(rdms.descriptors["exp"], "foo")
+        assert_array_equal(rdms.rdm_descriptors["session"], [1, 3, 5, 7])
+        assert_array_equal(rdms.rdm_descriptors["subject"], ["zoe", "joe", "max", "max"])
+        assert_array_equal(rdms.pattern_descriptors["cond"], ["a", "c", "b", "d"])
         assert_array_equal(
             rdms.dissimilarities,
             [
-                [ 2,  1,  3,  1,  1,  2],  # noqa: E201
-                [ 4,  2,  6,  2,  2,  4],  # noqa: E201
-                [ 6,  3,  9,  3,  3,  6],  # noqa: E201
-                [16, 13, 19, 13, 13, 16]   # noqa: E201
-            ]
+                [2, 1, 3, 1, 1, 2],  # noqa: E201
+                [4, 2, 6, 2, 2, 4],  # noqa: E201
+                [6, 3, 9, 3, 3, 6],  # noqa: E201
+                [16, 13, 19, 13, 13, 16],  # noqa: E201
+            ],
         )
 
     def test_concat_varargs_multiple_rdms(self):
         from rsatoolbox.rdm import concat
+
         dis = np.zeros((8, 10))
         dis2 = self.rng.random((8, 10))
         mes = "Euclidean"
-        des = {'subj': 0}
-        pattern_des = {'type': np.array([0, 1, 2, 2, 4])}
-        rdm_des = {'session': np.array([0, 1, 2, 2, 4, 5, 6, 7])}
-        rdms1 = rsr.RDMs(dissimilarities=dis,
-                         pattern_descriptors=pattern_des,
-                         dissimilarity_measure=mes,
-                         descriptors=des,
-                         rdm_descriptors=rdm_des)
-        rdms2 = rsr.RDMs(dissimilarities=dis2,
-                         pattern_descriptors=pattern_des,
-                         dissimilarity_measure=mes,
-                         descriptors=des,
-                         rdm_descriptors=rdm_des)
+        des = {"subj": 0}
+        pattern_des = {"type": np.array([0, 1, 2, 2, 4])}
+        rdm_des = {"session": np.array([0, 1, 2, 2, 4, 5, 6, 7])}
+        rdms1 = rsr.RDMs(
+            dissimilarities=dis,
+            pattern_descriptors=pattern_des,
+            dissimilarity_measure=mes,
+            descriptors=des,
+            rdm_descriptors=rdm_des,
+        )
+        rdms2 = rsr.RDMs(
+            dissimilarities=dis2,
+            pattern_descriptors=pattern_des,
+            dissimilarity_measure=mes,
+            descriptors=des,
+            rdm_descriptors=rdm_des,
+        )
         rdm_c1 = concat((rdms1, rdms2))
         rdm_c2 = concat(rdms1, rdms2)
         self.assertEqual(rdm_c1.n_rdm, 16)
@@ -423,177 +426,130 @@ class TestRDM(unittest.TestCase):
 
     def test_concat_varargs_one_rdm(self):
         from rsatoolbox.rdm import concat
+
         dis = np.zeros((8, 10))
         mes = "Euclidean"
-        des = {'subj': 0}
-        pattern_des = {'type': np.array([0, 1, 2, 2, 4])}
-        rdm_des = {'session': np.array([0, 1, 2, 2, 4, 5, 6, 7])}
-        rdms = rsr.RDMs(dissimilarities=dis,
-                        pattern_descriptors=pattern_des,
-                        dissimilarity_measure=mes,
-                        descriptors=des,
-                        rdm_descriptors=rdm_des)
+        des = {"subj": 0}
+        pattern_des = {"type": np.array([0, 1, 2, 2, 4])}
+        rdm_des = {"session": np.array([0, 1, 2, 2, 4, 5, 6, 7])}
+        rdms = rsr.RDMs(
+            dissimilarities=dis,
+            pattern_descriptors=pattern_des,
+            dissimilarity_measure=mes,
+            descriptors=des,
+            rdm_descriptors=rdm_des,
+        )
         rdm_c1 = concat(rdms)
         self.assertEqual(rdm_c1.n_rdm, 8)
         assert_array_equal(rdm_c1.dissimilarities, rdms.dissimilarities)
 
     def test_categorical_rdm(self):
         from rsatoolbox.rdm import get_categorical_rdm
+
         category_vector = [1, 2, 2, 3]
         rdm = get_categorical_rdm(category_vector)
         np.testing.assert_array_almost_equal(
-            rdm.dissimilarities,
-            np.array([[1., 1., 1., 0., 1., 1.]]))
+            rdm.dissimilarities, np.array([[1.0, 1.0, 1.0, 0.0, 1.0, 1.0]])
+        )
 
     def test_reorder(self):
         from rsatoolbox.rdm import RDMs
-        rdm = np.array([
-            [0., 1., 2., 3.],
-            [1., 0., 1., 2.],
-            [2., 1., 0., 1.],
-            [3., 2., 1., 0.]]
+
+        rdm = np.array(
+            [[0.0, 1.0, 2.0, 3.0], [1.0, 0.0, 1.0, 2.0], [2.0, 1.0, 0.0, 1.0], [3.0, 2.0, 1.0, 0.0]]
         )
-        conds = ['a', 'b', 'c', 'd']
-        rdms = RDMs(
-            np.atleast_2d(squareform(rdm)),
-            pattern_descriptors=dict(conds=conds)
-        )
-        conds_ordered = ['b', 'a', 'c', 'd']
-        new_order = [conds.index(cond_idx)
-                     for cond_idx in conds_ordered]
+        conds = ["a", "b", "c", "d"]
+        rdms = RDMs(np.atleast_2d(squareform(rdm)), pattern_descriptors=dict(conds=conds))
+        conds_ordered = ["b", "a", "c", "d"]
+        new_order = [conds.index(cond_idx) for cond_idx in conds_ordered]
         rdm_reordered = rdm[np.ix_(new_order, new_order)]
         rdms.reorder(new_order)
-        assert_array_equal(
-            np.atleast_2d(squareform(rdm_reordered)),
-            rdms.dissimilarities
-        )
-        assert_array_equal(
-            conds_ordered,
-            rdms.pattern_descriptors.get('conds')
-        )
+        assert_array_equal(np.atleast_2d(squareform(rdm_reordered)), rdms.dissimilarities)
+        assert_array_equal(conds_ordered, rdms.pattern_descriptors.get("conds"))
 
     def test_sort_by_alpha(self):
         from rsatoolbox.rdm import RDMs
-        rdm = np.array([
-            [0., 1., 2., 3.],
-            [1., 0., 1., 2.],
-            [2., 1., 0., 1.],
-            [3., 2., 1., 0.]]
+
+        rdm = np.array(
+            [[0.0, 1.0, 2.0, 3.0], [1.0, 0.0, 1.0, 2.0], [2.0, 1.0, 0.0, 1.0], [3.0, 2.0, 1.0, 0.0]]
         )
-        conds = ['b', 'a', 'c', 'd']
-        rdms = RDMs(
-            np.atleast_2d(squareform(rdm)),
-            pattern_descriptors=dict(conds=conds)
-        )
-        rdms.sort_by(conds='alpha')
+        conds = ["b", "a", "c", "d"]
+        rdms = RDMs(np.atleast_2d(squareform(rdm)), pattern_descriptors=dict(conds=conds))
+        rdms.sort_by(conds="alpha")
         new_order = np.argsort(conds)
         rdm_reordered = rdm[np.ix_(new_order, new_order)]
         self.assertIsNone(
-            assert_array_equal(
-                np.atleast_2d(squareform(rdm_reordered)),
-                rdms.dissimilarities
-            )
+            assert_array_equal(np.atleast_2d(squareform(rdm_reordered)), rdms.dissimilarities)
         )
-        self.assertIsNone(
-            assert_array_equal(
-                sorted(conds),
-                rdms.pattern_descriptors.get('conds')
-            )
-        )
+        self.assertIsNone(assert_array_equal(sorted(conds), rdms.pattern_descriptors.get("conds")))
 
     def test_sort_by_reindex_resets_index(self):
         from rsatoolbox.rdm import RDMs
-        rdm = np.array([
-            [0., 1., 2., 3.],
-            [1., 0., 1., 2.],
-            [2., 1., 0., 1.],
-            [3., 2., 1., 0.]]
+
+        rdm = np.array(
+            [[0.0, 1.0, 2.0, 3.0], [1.0, 0.0, 1.0, 2.0], [2.0, 1.0, 0.0, 1.0], [3.0, 2.0, 1.0, 0.0]]
         )
-        conds = ['b', 'a', 'c', 'd']
-        rdms = RDMs(
-            np.atleast_2d(squareform(rdm)),
-            pattern_descriptors=dict(conds=conds)
-        )
-        rdms.sort_by(conds='alpha', reindex=True)
-        self.assertEqual(
-            rdms.pattern_descriptors['index'],
-            list(range(rdms.n_cond))
-        )
+        conds = ["b", "a", "c", "d"]
+        rdms = RDMs(np.atleast_2d(squareform(rdm)), pattern_descriptors=dict(conds=conds))
+        rdms.sort_by(conds="alpha", reindex=True)
+        self.assertEqual(rdms.pattern_descriptors["index"], list(range(rdms.n_cond)))
 
     def test_sort_by_not_reindex_does_not_reset_index(self):
         from rsatoolbox.rdm import RDMs
-        rdm = np.array([
-            [0., 1., 2., 3.],
-            [1., 0., 1., 2.],
-            [2., 1., 0., 1.],
-            [3., 2., 1., 0.]]
+
+        rdm = np.array(
+            [[0.0, 1.0, 2.0, 3.0], [1.0, 0.0, 1.0, 2.0], [2.0, 1.0, 0.0, 1.0], [3.0, 2.0, 1.0, 0.0]]
         )
-        conds = ['b', 'a', 'c', 'd']
-        rdms = RDMs(
-            np.atleast_2d(squareform(rdm)),
-            pattern_descriptors=dict(conds=conds)
-        )
-        rdms.sort_by(conds='alpha', reindex=False)
-        self.assertNotEqual(
-            rdms.pattern_descriptors['index'],
-            list(range(rdms.n_cond))
-        )
+        conds = ["b", "a", "c", "d"]
+        rdms = RDMs(np.atleast_2d(squareform(rdm)), pattern_descriptors=dict(conds=conds))
+        rdms.sort_by(conds="alpha", reindex=False)
+        self.assertNotEqual(rdms.pattern_descriptors["index"], list(range(rdms.n_cond)))
 
     def test_sort_by_list(self):
         from rsatoolbox.rdm import RDMs
-        rdm = np.array([
-            [0., 1., 2., 3.],
-            [1., 0., 1., 2.],
-            [2., 1., 0., 1.],
-            [3., 2., 1., 0.]]
+
+        rdm = np.array(
+            [[0.0, 1.0, 2.0, 3.0], [1.0, 0.0, 1.0, 2.0], [2.0, 1.0, 0.0, 1.0], [3.0, 2.0, 1.0, 0.0]]
         )
-        conds = ['a', 'b', 'c', 'd']
-        rdms = RDMs(
-            np.atleast_2d(squareform(rdm)),
-            pattern_descriptors=dict(conds=conds)
-        )
-        conds_new_order = ['c', 'd', 'b', 'a']
+        conds = ["a", "b", "c", "d"]
+        rdms = RDMs(np.atleast_2d(squareform(rdm)), pattern_descriptors=dict(conds=conds))
+        conds_new_order = ["c", "d", "b", "a"]
         rdms.sort_by(conds=conds_new_order)
 
         new_order = np.array([conds.index(c) for c in conds_new_order])
         rdm_reordered = rdm[np.ix_(new_order, new_order)]
         self.assertIsNone(
-            assert_array_equal(
-                np.atleast_2d(squareform(rdm_reordered)),
-                rdms.dissimilarities
-            )
+            assert_array_equal(np.atleast_2d(squareform(rdm_reordered)), rdms.dissimilarities)
         )
         self.assertIsNone(
-            assert_array_equal(
-                conds_new_order,
-                rdms.pattern_descriptors.get('conds')
-            )
+            assert_array_equal(conds_new_order, rdms.pattern_descriptors.get("conds"))
         )
 
     def test_sort_stable(self):
         from rsatoolbox.rdm import RDMs
-        rdm = np.array([
-            [0., 1., 2., 3., 4., 5., 6., 7., 8., 9.],
-            [1., 0., 1., 2., 3., 4., 5., 6., 7., 8.],
-            [2., 1., 0., 1., 2., 3., 4., 5., 6., 7.],
-            [3., 2., 1., 0., 1., 2., 3., 4., 5., 6.],
-            [4., 3., 2., 1., 0., 1., 2., 3., 4., 5.],
-            [5., 4., 3., 2., 1., 0., 1., 2., 3., 4.],
-            [6., 5., 4., 3., 2., 1., 0., 1., 2., 3.],
-            [7., 6., 5., 4., 3., 2., 1., 0., 1., 2.],
-            [8., 7., 6., 5., 4., 3., 2., 1., 0., 1.],
-            [9., 8., 7., 6., 5., 4., 3., 2., 1., 0.],
-        ]
+
+        rdm = np.array(
+            [
+                [0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0],
+                [1.0, 0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0],
+                [2.0, 1.0, 0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0],
+                [3.0, 2.0, 1.0, 0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0],
+                [4.0, 3.0, 2.0, 1.0, 0.0, 1.0, 2.0, 3.0, 4.0, 5.0],
+                [5.0, 4.0, 3.0, 2.0, 1.0, 0.0, 1.0, 2.0, 3.0, 4.0],
+                [6.0, 5.0, 4.0, 3.0, 2.0, 1.0, 0.0, 1.0, 2.0, 3.0],
+                [7.0, 6.0, 5.0, 4.0, 3.0, 2.0, 1.0, 0.0, 1.0, 2.0],
+                [8.0, 7.0, 6.0, 5.0, 4.0, 3.0, 2.0, 1.0, 0.0, 1.0],
+                [9.0, 8.0, 7.0, 6.0, 5.0, 4.0, 3.0, 2.0, 1.0, 0.0],
+            ]
         )
         conds = list(reversed("abcdefghij"))
         cats = list("ababababab")
         rdms = RDMs(
-            np.atleast_2d(squareform(rdm)),
-            pattern_descriptors=dict(conds=conds, cats=cats)
+            np.atleast_2d(squareform(rdm)), pattern_descriptors=dict(conds=conds, cats=cats)
         )
         # Randomise the condition labels first
         rdms.sort_by(index=np.random.permutation(rdms.n_cond).tolist())
-        rdms.sort_by(conds='alpha')
+        rdms.sort_by(conds="alpha")
         rdms.sort_by(cats="alpha")
         self.assertListEqual(
             list(rdms.pattern_descriptors["conds"]),
@@ -602,59 +558,49 @@ class TestRDM(unittest.TestCase):
 
     def test_copy(self):
         from rsatoolbox.rdm import RDMs
+
         orig = RDMs(
             dissimilarities=self.rng.random((2, 3)),
-            dissimilarity_measure='euclidean',
-            descriptors=dict(foo='bar', baz='foz'),
-            rdm_descriptors=dict(thrusters=['port', 'starboard']),
-            pattern_descriptors=dict(
-                names=['a', 'b', 'c'],
-                order=np.array([6, 7, 8])
-            )
+            dissimilarity_measure="euclidean",
+            descriptors=dict(foo="bar", baz="foz"),
+            rdm_descriptors=dict(thrusters=["port", "starboard"]),
+            pattern_descriptors=dict(names=["a", "b", "c"], order=np.array([6, 7, 8])),
         )
         copy = orig.copy()
         # We don't want a reference:
         self.assertIsNot(copy, orig)
         self.assertIsNot(copy.dissimilarities, orig.dissimilarities)
         self.assertIsNot(
-            copy.pattern_descriptors.get('order'),
-            orig.pattern_descriptors.get('order')
+            copy.pattern_descriptors.get("order"), orig.pattern_descriptors.get("order")
         )
         # But check that attributes are equal
         assert_array_equal(copy.dissimilarities, orig.dissimilarities)
-        self.assertEqual(
-            copy.dissimilarity_measure,
-            orig.dissimilarity_measure
-        )
+        self.assertEqual(copy.dissimilarity_measure, orig.dissimilarity_measure)
         self.assertEqual(copy.descriptors, orig.descriptors)
         self.assertEqual(copy.rdm_descriptors, orig.rdm_descriptors)
         assert_array_equal(
-            copy.pattern_descriptors.get('names'),
-            orig.pattern_descriptors.get('names')
+            copy.pattern_descriptors.get("names"), orig.pattern_descriptors.get("names")
         )
         assert_array_equal(
-            copy.pattern_descriptors.get('order'),
-            orig.pattern_descriptors.get('order')
+            copy.pattern_descriptors.get("order"), orig.pattern_descriptors.get("order")
         )
 
     def test_equality(self):
         from rsatoolbox.rdm import RDMs
+
         orig = RDMs(
             dissimilarities=self.rng.random((2, 3)),
-            dissimilarity_measure='euclidean',
-            descriptors=dict(foo='bar', baz='foz'),
-            rdm_descriptors=dict(thrusters=['port', 'starboard']),
-            pattern_descriptors=dict(
-                names=['a', 'b', 'c'],
-                order=np.array([6, 7, 8])
-            )
+            dissimilarity_measure="euclidean",
+            descriptors=dict(foo="bar", baz="foz"),
+            rdm_descriptors=dict(thrusters=["port", "starboard"]),
+            pattern_descriptors=dict(names=["a", "b", "c"], order=np.array([6, 7, 8])),
         )
         self.assertEqual(orig, orig.copy())
         other1 = orig.copy()
         other1.dissimilarities[1, 1] = 1.1
         self.assertNotEqual(orig, other1)
         other2 = orig.copy()
-        other2.pattern_descriptors['order'][1] = 10
+        other2.pattern_descriptors["order"][1] = 10
         self.assertNotEqual(orig, other2)
 
 
@@ -662,201 +608,225 @@ class TestSave(unittest.TestCase):
     def test_dict_conversion(self):
         dis = np.zeros((8, 10))
         mes = "Euclidean"
-        des = {'subj': 0}
-        pattern_des = {'type': np.array([0, 1, 2, 2, 4])}
-        rdm_des = {'session': np.array([0, 1, 2, 2, 4, 5, 6, 7])}
+        des = {"subj": 0}
+        pattern_des = {"type": np.array([0, 1, 2, 2, 4])}
+        rdm_des = {"session": np.array([0, 1, 2, 2, 4, 5, 6, 7])}
         rdms = rsa.rdm.RDMs(
             dissimilarities=dis,
             pattern_descriptors=pattern_des,
             dissimilarity_measure=mes,
             descriptors=des,
-            rdm_descriptors=rdm_des)
+            rdm_descriptors=rdm_des,
+        )
         rdm_dict = rdms.to_dict()
         rdms_loaded = rsa.rdm.rdms_from_dict(rdm_dict)
         assert rdms_loaded.n_cond == rdms.n_cond
-        assert np.all(rdms_loaded.pattern_descriptors['type']
-                      == pattern_des['type'])
-        assert np.all(rdms_loaded.rdm_descriptors['session']
-                      == rdm_des['session'])
-        assert rdms_loaded.descriptors['subj'] == 0
+        assert np.all(rdms_loaded.pattern_descriptors["type"] == pattern_des["type"])
+        assert np.all(rdms_loaded.rdm_descriptors["session"] == rdm_des["session"])
+        assert rdms_loaded.descriptors["subj"] == 0
 
     def test_save_load(self):
         import io
+
         f = io.BytesIO()  # Essentially a Mock file
         dis = np.zeros((8, 10))
         mes = "Euclidean"
-        des = {'subj': 0}
-        pattern_des = {'type': np.array([0, 1, 2, 2, 4])}
-        rdm_des = {'session': np.array([0, 1, 2, 2, 4, 5, 6, 7])}
+        des = {"subj": 0}
+        pattern_des = {"type": np.array([0, 1, 2, 2, 4])}
+        rdm_des = {"session": np.array([0, 1, 2, 2, 4, 5, 6, 7])}
         rdms = rsa.rdm.RDMs(
             dissimilarities=dis,
             pattern_descriptors=pattern_des,
             dissimilarity_measure=mes,
             descriptors=des,
-            rdm_descriptors=rdm_des)
-        rdms.save(f, file_type='hdf5')
-        rdms_loaded = rsa.rdm.load_rdm(f, file_type='hdf5')
+            rdm_descriptors=rdm_des,
+        )
+        rdms.save(f, file_type="hdf5")
+        rdms_loaded = rsa.rdm.load_rdm(f, file_type="hdf5")
         assert rdms_loaded.n_cond == rdms.n_cond
-        assert np.all(rdms_loaded.pattern_descriptors['type']
-                      == pattern_des['type'])
-        assert np.all(rdms_loaded.rdm_descriptors['session']
-                      == rdm_des['session'])
-        assert rdms_loaded.descriptors['subj'] == 0
+        assert np.all(rdms_loaded.pattern_descriptors["type"] == pattern_des["type"])
+        assert np.all(rdms_loaded.rdm_descriptors["session"] == rdm_des["session"])
+        assert rdms_loaded.descriptors["subj"] == 0
+
+    def test_save_load_noise(self):
+        import io
+
+        f = io.BytesIO()  # Essentially a Mock file
+        testRDM = rsa.rdm.rdms.RDMs(
+            np.random.rand(2, 10, 10),
+            "crossnobis",
+            rdm_descriptors={"noise": [np.random.rand(5, 5), np.random.rand(6, 6)], "subj": [1, 2]},
+        )
+        testRDM.save(f, file_type="hdf5")
+        rdms_loaded = rsa.rdm.load_rdm(f, file_type="hdf5")
+        assert rdms_loaded.n_cond == testRDM.n_cond
+        assert rdms_loaded.rdm_descriptors["subj"][0] == 1
+        assert rdms_loaded.rdm_descriptors["noise"][0].shape == (5, 5)
+        assert rdms_loaded.rdm_descriptors["noise"][1].shape == (6, 6)
 
 
 class TestRDMLists(unittest.TestCase):
-    """ checking that descriptors stay lists if they are specified as such"""
+    """checking that descriptors stay lists if they are specified as such"""
 
     def setUp(self):
         self.rng = np.random.default_rng(0)
         dissimilarities = self.rng.random((3, 15))
-        des = {'session': 0, 'subj': np.arange(7)}
-        rdm_des = {'test': ['a', np.arange(5), None]}
-        pattern_des = {'test': [np.arange(1), np.arange(2), np.arange(3),
-                                np.arange(4), np.arange(5), np.arange(6)],
-                       'test2': [1, 2, 3, 4, 5, 6],
-                       'test3': [np.arange(1), np.arange(2), np.arange(1),
-                                 np.arange(1), np.arange(1), 'b']}
+        des = {"session": 0, "subj": np.arange(7)}
+        rdm_des = {"test": ["a", np.arange(5), None]}
+        pattern_des = {
+            "test": [
+                np.arange(1),
+                np.arange(2),
+                np.arange(3),
+                np.arange(4),
+                np.arange(5),
+                np.arange(6),
+            ],
+            "test2": [1, 2, 3, 4, 5, 6],
+            "test3": [np.arange(1), np.arange(2), np.arange(1), np.arange(1), np.arange(1), "b"],
+        }
         self.test_rdm = rsa.rdm.RDMs(
             dissimilarities=dissimilarities,
-            dissimilarity_measure='test',
+            dissimilarity_measure="test",
             descriptors=des,
             rdm_descriptors=rdm_des,
-            pattern_descriptors=pattern_des
+            pattern_descriptors=pattern_des,
         )
 
     def test_rdm_init_list(self):
-        assert isinstance(self.test_rdm.rdm_descriptors['index'], list)
-        assert isinstance(self.test_rdm.pattern_descriptors['index'], list)
-        assert isinstance(self.test_rdm.rdm_descriptors['test'], list)
-        assert isinstance(self.test_rdm.pattern_descriptors['test'], list)
-        assert isinstance(self.test_rdm.pattern_descriptors['test2'], list)
-        assert isinstance(self.test_rdm.pattern_descriptors['test3'], list)
+        assert isinstance(self.test_rdm.rdm_descriptors["index"], list)
+        assert isinstance(self.test_rdm.pattern_descriptors["index"], list)
+        assert isinstance(self.test_rdm.rdm_descriptors["test"], list)
+        assert isinstance(self.test_rdm.pattern_descriptors["test"], list)
+        assert isinstance(self.test_rdm.pattern_descriptors["test2"], list)
+        assert isinstance(self.test_rdm.pattern_descriptors["test3"], list)
 
     def test_rdm_indexing(self):
         from copy import deepcopy
+
         rdm = deepcopy(self.test_rdm)
         rdms = rdm[1, 2]
         rdm = rdm[0]
-        assert isinstance(rdms.rdm_descriptors['index'], list)
-        assert isinstance(rdms.pattern_descriptors['index'], list)
-        assert isinstance(rdms.rdm_descriptors['test'], list)
-        assert isinstance(rdms.pattern_descriptors['test'], list)
-        assert isinstance(rdms.pattern_descriptors['test2'], list)
-        assert isinstance(rdms.pattern_descriptors['test3'], list)
+        assert isinstance(rdms.rdm_descriptors["index"], list)
+        assert isinstance(rdms.pattern_descriptors["index"], list)
+        assert isinstance(rdms.rdm_descriptors["test"], list)
+        assert isinstance(rdms.pattern_descriptors["test"], list)
+        assert isinstance(rdms.pattern_descriptors["test2"], list)
+        assert isinstance(rdms.pattern_descriptors["test3"], list)
         self.assertEqual(rdms.n_rdm, 2)
-        assert isinstance(rdm.rdm_descriptors['index'], list)
-        assert isinstance(rdm.pattern_descriptors['index'], list)
-        assert isinstance(rdm.rdm_descriptors['test'], list)
-        assert isinstance(rdm.pattern_descriptors['test'], list)
-        assert isinstance(rdm.pattern_descriptors['test2'], list)
-        assert isinstance(rdm.pattern_descriptors['test3'], list)
+        assert isinstance(rdm.rdm_descriptors["index"], list)
+        assert isinstance(rdm.pattern_descriptors["index"], list)
+        assert isinstance(rdm.rdm_descriptors["test"], list)
+        assert isinstance(rdm.pattern_descriptors["test"], list)
+        assert isinstance(rdm.pattern_descriptors["test2"], list)
+        assert isinstance(rdm.pattern_descriptors["test3"], list)
         self.assertEqual(rdm.n_rdm, 1)
 
     def test_rdm_subset_list(self):
-        sub_rdm = self.test_rdm.subset('index', 0)
-        sub_rdm2 = self.test_rdm.subset('index', [0, 1])
-        assert isinstance(self.test_rdm.rdm_descriptors['index'], list)
-        assert isinstance(self.test_rdm.pattern_descriptors['index'], list)
-        assert isinstance(self.test_rdm.rdm_descriptors['test'], list)
-        assert isinstance(self.test_rdm.pattern_descriptors['test'], list)
-        assert isinstance(self.test_rdm.pattern_descriptors['test2'], list)
-        assert isinstance(self.test_rdm.pattern_descriptors['test3'], list)
-        assert isinstance(sub_rdm.rdm_descriptors['index'], list)
-        assert isinstance(sub_rdm.pattern_descriptors['index'], list)
-        assert isinstance(sub_rdm.rdm_descriptors['test'], list)
-        assert isinstance(sub_rdm.pattern_descriptors['test'], list)
-        assert isinstance(sub_rdm.pattern_descriptors['test2'], list)
-        assert isinstance(sub_rdm.pattern_descriptors['test3'], list)
-        assert isinstance(sub_rdm2.rdm_descriptors['index'], list)
-        assert isinstance(sub_rdm2.pattern_descriptors['index'], list)
-        assert isinstance(sub_rdm2.rdm_descriptors['test'], list)
-        assert isinstance(sub_rdm2.pattern_descriptors['test'], list)
-        assert isinstance(sub_rdm2.pattern_descriptors['test2'], list)
-        assert isinstance(sub_rdm2.pattern_descriptors['test3'], list)
+        sub_rdm = self.test_rdm.subset("index", 0)
+        sub_rdm2 = self.test_rdm.subset("index", [0, 1])
+        assert isinstance(self.test_rdm.rdm_descriptors["index"], list)
+        assert isinstance(self.test_rdm.pattern_descriptors["index"], list)
+        assert isinstance(self.test_rdm.rdm_descriptors["test"], list)
+        assert isinstance(self.test_rdm.pattern_descriptors["test"], list)
+        assert isinstance(self.test_rdm.pattern_descriptors["test2"], list)
+        assert isinstance(self.test_rdm.pattern_descriptors["test3"], list)
+        assert isinstance(sub_rdm.rdm_descriptors["index"], list)
+        assert isinstance(sub_rdm.pattern_descriptors["index"], list)
+        assert isinstance(sub_rdm.rdm_descriptors["test"], list)
+        assert isinstance(sub_rdm.pattern_descriptors["test"], list)
+        assert isinstance(sub_rdm.pattern_descriptors["test2"], list)
+        assert isinstance(sub_rdm.pattern_descriptors["test3"], list)
+        assert isinstance(sub_rdm2.rdm_descriptors["index"], list)
+        assert isinstance(sub_rdm2.pattern_descriptors["index"], list)
+        assert isinstance(sub_rdm2.rdm_descriptors["test"], list)
+        assert isinstance(sub_rdm2.pattern_descriptors["test"], list)
+        assert isinstance(sub_rdm2.pattern_descriptors["test2"], list)
+        assert isinstance(sub_rdm2.pattern_descriptors["test3"], list)
 
     def test_rdm_subsample_list(self):
-        sub_rdm = self.test_rdm.subsample('index', 0)
-        sub_rdm2 = self.test_rdm.subsample('index', [0, 1, 1])
-        assert isinstance(self.test_rdm.rdm_descriptors['index'], list)
-        assert isinstance(self.test_rdm.pattern_descriptors['index'], list)
-        assert isinstance(self.test_rdm.rdm_descriptors['test'], list)
-        assert isinstance(self.test_rdm.pattern_descriptors['test'], list)
-        assert isinstance(self.test_rdm.pattern_descriptors['test2'], list)
-        assert isinstance(self.test_rdm.pattern_descriptors['test3'], list)
-        assert isinstance(sub_rdm.rdm_descriptors['index'], list)
-        assert isinstance(sub_rdm.pattern_descriptors['index'], list)
-        assert isinstance(sub_rdm.rdm_descriptors['test'], list)
-        assert isinstance(sub_rdm.pattern_descriptors['test'], list)
-        assert isinstance(sub_rdm.pattern_descriptors['test2'], list)
-        assert isinstance(sub_rdm.pattern_descriptors['test3'], list)
-        assert isinstance(sub_rdm2.rdm_descriptors['index'], list)
-        assert isinstance(sub_rdm2.pattern_descriptors['index'], list)
-        assert isinstance(sub_rdm2.rdm_descriptors['test'], list)
-        assert isinstance(sub_rdm2.pattern_descriptors['test'], list)
-        assert isinstance(sub_rdm2.pattern_descriptors['test2'], list)
-        assert isinstance(sub_rdm2.pattern_descriptors['test3'], list)
+        sub_rdm = self.test_rdm.subsample("index", 0)
+        sub_rdm2 = self.test_rdm.subsample("index", [0, 1, 1])
+        assert isinstance(self.test_rdm.rdm_descriptors["index"], list)
+        assert isinstance(self.test_rdm.pattern_descriptors["index"], list)
+        assert isinstance(self.test_rdm.rdm_descriptors["test"], list)
+        assert isinstance(self.test_rdm.pattern_descriptors["test"], list)
+        assert isinstance(self.test_rdm.pattern_descriptors["test2"], list)
+        assert isinstance(self.test_rdm.pattern_descriptors["test3"], list)
+        assert isinstance(sub_rdm.rdm_descriptors["index"], list)
+        assert isinstance(sub_rdm.pattern_descriptors["index"], list)
+        assert isinstance(sub_rdm.rdm_descriptors["test"], list)
+        assert isinstance(sub_rdm.pattern_descriptors["test"], list)
+        assert isinstance(sub_rdm.pattern_descriptors["test2"], list)
+        assert isinstance(sub_rdm.pattern_descriptors["test3"], list)
+        assert isinstance(sub_rdm2.rdm_descriptors["index"], list)
+        assert isinstance(sub_rdm2.pattern_descriptors["index"], list)
+        assert isinstance(sub_rdm2.rdm_descriptors["test"], list)
+        assert isinstance(sub_rdm2.pattern_descriptors["test"], list)
+        assert isinstance(sub_rdm2.pattern_descriptors["test2"], list)
+        assert isinstance(sub_rdm2.pattern_descriptors["test3"], list)
         self.assertEqual(sub_rdm2.n_rdm, 3)
 
     def test_pattern_subset_list(self):
-        sub_rdm = self.test_rdm.subset_pattern('test2', 4)
-        sub_rdm2 = self.test_rdm.subset_pattern('index', [0, 1])
-        assert isinstance(self.test_rdm.rdm_descriptors['index'], list)
-        assert isinstance(self.test_rdm.pattern_descriptors['index'], list)
-        assert isinstance(self.test_rdm.rdm_descriptors['test'], list)
-        assert isinstance(self.test_rdm.pattern_descriptors['test'], list)
-        assert isinstance(self.test_rdm.pattern_descriptors['test2'], list)
-        assert isinstance(self.test_rdm.pattern_descriptors['test3'], list)
-        assert isinstance(sub_rdm.rdm_descriptors['index'], list)
-        assert isinstance(sub_rdm.pattern_descriptors['index'], list)
-        assert isinstance(sub_rdm.rdm_descriptors['test'], list)
-        assert isinstance(sub_rdm.pattern_descriptors['test'], list)
-        assert isinstance(sub_rdm.pattern_descriptors['test2'], list)
-        assert isinstance(sub_rdm.pattern_descriptors['test3'], list)
-        assert isinstance(sub_rdm2.rdm_descriptors['index'], list)
-        assert isinstance(sub_rdm2.pattern_descriptors['index'], list)
-        assert isinstance(sub_rdm2.rdm_descriptors['test'], list)
-        assert isinstance(sub_rdm2.pattern_descriptors['test'], list)
-        assert isinstance(sub_rdm2.pattern_descriptors['test2'], list)
-        assert isinstance(sub_rdm2.pattern_descriptors['test3'], list)
+        sub_rdm = self.test_rdm.subset_pattern("test2", 4)
+        sub_rdm2 = self.test_rdm.subset_pattern("index", [0, 1])
+        assert isinstance(self.test_rdm.rdm_descriptors["index"], list)
+        assert isinstance(self.test_rdm.pattern_descriptors["index"], list)
+        assert isinstance(self.test_rdm.rdm_descriptors["test"], list)
+        assert isinstance(self.test_rdm.pattern_descriptors["test"], list)
+        assert isinstance(self.test_rdm.pattern_descriptors["test2"], list)
+        assert isinstance(self.test_rdm.pattern_descriptors["test3"], list)
+        assert isinstance(sub_rdm.rdm_descriptors["index"], list)
+        assert isinstance(sub_rdm.pattern_descriptors["index"], list)
+        assert isinstance(sub_rdm.rdm_descriptors["test"], list)
+        assert isinstance(sub_rdm.pattern_descriptors["test"], list)
+        assert isinstance(sub_rdm.pattern_descriptors["test2"], list)
+        assert isinstance(sub_rdm.pattern_descriptors["test3"], list)
+        assert isinstance(sub_rdm2.rdm_descriptors["index"], list)
+        assert isinstance(sub_rdm2.pattern_descriptors["index"], list)
+        assert isinstance(sub_rdm2.rdm_descriptors["test"], list)
+        assert isinstance(sub_rdm2.pattern_descriptors["test"], list)
+        assert isinstance(sub_rdm2.pattern_descriptors["test2"], list)
+        assert isinstance(sub_rdm2.pattern_descriptors["test3"], list)
         self.assertEqual(sub_rdm.n_cond, 1)
         self.assertEqual(sub_rdm2.n_cond, 2)
 
     def test_pattern_subsample_list(self):
-        sub_rdm = self.test_rdm.subsample_pattern('test2', 4)
-        sub_rdm2 = self.test_rdm.subsample_pattern('index', [0, 1, 1, 2])
-        assert isinstance(self.test_rdm.rdm_descriptors['index'], list)
-        assert isinstance(self.test_rdm.pattern_descriptors['index'], list)
-        assert isinstance(self.test_rdm.rdm_descriptors['test'], list)
-        assert isinstance(self.test_rdm.pattern_descriptors['test'], list)
-        assert isinstance(self.test_rdm.pattern_descriptors['test2'], list)
-        assert isinstance(self.test_rdm.pattern_descriptors['test3'], list)
-        assert isinstance(sub_rdm.rdm_descriptors['index'], list)
-        assert isinstance(sub_rdm.pattern_descriptors['index'], list)
-        assert isinstance(sub_rdm.rdm_descriptors['test'], list)
-        assert isinstance(sub_rdm.pattern_descriptors['test'], list)
-        assert isinstance(sub_rdm.pattern_descriptors['test2'], list)
-        assert isinstance(sub_rdm.pattern_descriptors['test3'], list)
-        assert isinstance(sub_rdm2.rdm_descriptors['index'], list)
-        assert isinstance(sub_rdm2.pattern_descriptors['index'], list)
-        assert isinstance(sub_rdm2.rdm_descriptors['test'], list)
-        assert isinstance(sub_rdm2.pattern_descriptors['test'], list)
-        assert isinstance(sub_rdm2.pattern_descriptors['test2'], list)
-        assert isinstance(sub_rdm2.pattern_descriptors['test3'], list)
+        sub_rdm = self.test_rdm.subsample_pattern("test2", 4)
+        sub_rdm2 = self.test_rdm.subsample_pattern("index", [0, 1, 1, 2])
+        assert isinstance(self.test_rdm.rdm_descriptors["index"], list)
+        assert isinstance(self.test_rdm.pattern_descriptors["index"], list)
+        assert isinstance(self.test_rdm.rdm_descriptors["test"], list)
+        assert isinstance(self.test_rdm.pattern_descriptors["test"], list)
+        assert isinstance(self.test_rdm.pattern_descriptors["test2"], list)
+        assert isinstance(self.test_rdm.pattern_descriptors["test3"], list)
+        assert isinstance(sub_rdm.rdm_descriptors["index"], list)
+        assert isinstance(sub_rdm.pattern_descriptors["index"], list)
+        assert isinstance(sub_rdm.rdm_descriptors["test"], list)
+        assert isinstance(sub_rdm.pattern_descriptors["test"], list)
+        assert isinstance(sub_rdm.pattern_descriptors["test2"], list)
+        assert isinstance(sub_rdm.pattern_descriptors["test3"], list)
+        assert isinstance(sub_rdm2.rdm_descriptors["index"], list)
+        assert isinstance(sub_rdm2.pattern_descriptors["index"], list)
+        assert isinstance(sub_rdm2.rdm_descriptors["test"], list)
+        assert isinstance(sub_rdm2.pattern_descriptors["test"], list)
+        assert isinstance(sub_rdm2.pattern_descriptors["test2"], list)
+        assert isinstance(sub_rdm2.pattern_descriptors["test3"], list)
         self.assertEqual(sub_rdm2.n_cond, 4)
 
     def test_rdm_append_list(self):
         from copy import deepcopy
+
         long_rdm = deepcopy(self.test_rdm)
         long_rdm.append(long_rdm)
-        assert isinstance(long_rdm.rdm_descriptors['index'], list)
-        assert isinstance(long_rdm.pattern_descriptors['index'], list)
-        assert isinstance(long_rdm.rdm_descriptors['test'], list)
-        assert isinstance(long_rdm.pattern_descriptors['test'], list)
-        assert isinstance(long_rdm.pattern_descriptors['test2'], list)
-        assert isinstance(long_rdm.pattern_descriptors['test3'], list)
+        assert isinstance(long_rdm.rdm_descriptors["index"], list)
+        assert isinstance(long_rdm.pattern_descriptors["index"], list)
+        assert isinstance(long_rdm.rdm_descriptors["test"], list)
+        assert isinstance(long_rdm.pattern_descriptors["test"], list)
+        assert isinstance(long_rdm.pattern_descriptors["test2"], list)
+        assert isinstance(long_rdm.pattern_descriptors["test3"], list)
         self.assertEqual(long_rdm.n_rdm, 6)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
This pull request resolves #454 

There was an issue where saving noises of different sizes failed. Here I simply added the error type for stacking arrays of different sizes to the saving algorithm. I include the test from the issue which now passes.