### PR TITLE
Drop python 3.9 support, add 3.14

### DIFF
--- a/.github/workflows/testbuild.yml
+++ b/.github/workflows/testbuild.yml
@@ -39,7 +39,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
+        python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
         os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
     - uses: actions/checkout@v4
@@ -102,7 +102,7 @@ jobs:
     - name: Update Pip
       run: python -m pip install --upgrade pip
     - name: Install cibuildwheel
-      run: python -m pip install cibuildwheel==3.0.0
+      run: python -m pip install cibuildwheel~=3.3.1
     - name: Build wheels
       run: python -m cibuildwheel --output-dir dist
     - name: Check package compliance

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "rsatoolbox"
 description = "Representational Similarity Analysis (RSA) in Python"
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 authors = [
     {name="rsatoolbox authors"},
 ]
@@ -26,11 +26,11 @@ classifiers = [
       'Development Status :: 4 - Beta',
       'Topic :: Scientific/Engineering',
       'Intended Audience :: Science/Research',
-      'Programming Language :: Python :: 3.9',
       'Programming Language :: Python :: 3.10',
       'Programming Language :: Python :: 3.11',
       'Programming Language :: Python :: 3.12',
       'Programming Language :: Python :: 3.13',
+      'Programming Language :: Python :: 3.14',
 ]
 dynamic = ["readme", "dependencies", "version"]
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,7 +65,9 @@ addopts = "--assert=plain"
 test-requires = "pytest"
 test-command = "pytest {project}/tests"
 before-test = "pip install -r tests/requirements.txt"
-skip = ["*-win32", "*-manylinux_i686", "*-musllinux_*", "pp*"]
+skip = ["*-win32", "*-manylinux_i686", "*-musllinux_*", "pp*", "cp3??t-*"]
+# Free-threading builds disabled on all platforms as
+# no h5py wheels for cp314t https://docs.h5py.org/en/latest/threads.html
 
 [tool.pyright]
 include = ["src"]


### PR DESCRIPTION
Python 3.9 has been EOL since October last year. Python 3.14 is now an official release.

resolves #462 